### PR TITLE
[Feature] Statistic image

### DIFF
--- a/docs/code/guide/components/statistic/image.vue
+++ b/docs/code/guide/components/statistic/image.vue
@@ -1,0 +1,12 @@
+<template>
+    <FluxStatistic style="max-width: 350px"
+        label="Label"
+        value="Value"
+        image-src="https://avatars.githubusercontent.com/u/978257?v=4"/>
+</template>
+
+<script
+    setup
+    lang="ts">
+    import { FluxStatistic } from '@flux-ui/components';
+</script>

--- a/docs/code/guide/components/statistic/preview.vue
+++ b/docs/code/guide/components/statistic/preview.vue
@@ -10,6 +10,11 @@
                 value="Value"/>
 
             <FluxStatistic
+                label="Label"
+                value="Value"
+                image-src="https://avatars.githubusercontent.com/u/978257?v=4"/>
+
+            <FluxStatistic
                 icon="users"
                 color="danger"
                 label="Active users this month"

--- a/docs/guide/components/statistic.md
+++ b/docs/guide/components/statistic.md
@@ -41,6 +41,16 @@ props:
     -   name: value
         description: The value of the statistic.
         type: string
+
+    -   name: image-src
+        description: The image of the statistic.
+        type: string
+        optional: true
+
+    -   name: image-alt
+        description: The alt tag for the image.
+        type: string
+        optional: true
 ---
 
 # Statistic
@@ -65,6 +75,10 @@ example=../../code/guide/components/statistic/vertical.vue
 
 ::: example Change || A statistic with change details.
 example=../../code/guide/components/statistic/change.vue
+:::
+
+::: example Image || A statistic with an image.
+example=../../code/guide/components/statistic/image.vue
 :::
 
 ## Used components

--- a/docs/guide/components/statistic.md
+++ b/docs/guide/components/statistic.md
@@ -33,6 +33,7 @@ props:
     -   name: icon
         description: The icon of the statistic.
         type: FluxIconName
+        optional: true
 
     -   name: label
         description: The label of the statistic.

--- a/packages/components/src/component/FluxStatistic.vue
+++ b/packages/components/src/component/FluxStatistic.vue
@@ -10,8 +10,9 @@
             color === 'success' && $style.isSuccess,
             color === 'warning' && $style.isWarning
         )">
-        <div v-if="icon"
-             :class="$style.statisticIcon">
+        <div
+            v-if="icon"
+            :class="$style.statisticIcon">
             <FluxIcon
                 :name="icon"
                 :size="24"/>

--- a/packages/components/src/component/FluxStatistic.vue
+++ b/packages/components/src/component/FluxStatistic.vue
@@ -10,10 +10,17 @@
             color === 'success' && $style.isSuccess,
             color === 'warning' && $style.isWarning
         )">
-        <div :class="$style.statisticIcon">
+        <div :class="$style.statisticIcon" v-if="icon">
             <FluxIcon
                 :name="icon"
                 :size="24"/>
+        </div>
+
+        <div v-else-if="imageSrc">
+            <img
+                :class="$style.statisticImage"
+                :src="imageSrc"
+                :alt="imageAlt"/>
         </div>
 
         <div :class="$style.statisticData">
@@ -61,7 +68,9 @@
         readonly changeValue?: string;
         readonly color?: FluxColor;
         readonly direction?: FluxDirection;
-        readonly icon: FluxIconName;
+        readonly icon?: FluxIconName;
+        readonly imageSrc?: string;
+        readonly imageAlt?: string;
         readonly label: string;
         readonly value: string;
     }>();

--- a/packages/components/src/component/FluxStatistic.vue
+++ b/packages/components/src/component/FluxStatistic.vue
@@ -10,7 +10,8 @@
             color === 'success' && $style.isSuccess,
             color === 'warning' && $style.isWarning
         )">
-        <div :class="$style.statisticIcon" v-if="icon">
+        <div v-if="icon"
+             :class="$style.statisticIcon">
             <FluxIcon
                 :name="icon"
                 :size="24"/>

--- a/packages/components/src/css/component/Statistic.module.scss
+++ b/packages/components/src/css/component/Statistic.module.scss
@@ -96,6 +96,12 @@
     border-radius: var(--radius);
 }
 
+.statisticImage {
+    height: 48px;
+    width: 48px;
+    border-radius: var(--radius);
+}
+
 .statisticHorizontal {
     composes: statistic;
 


### PR DESCRIPTION
This PR introduces a new addition to the current existing `FluxStatistic` component.

I’ve added support for using an image instead of an icon in a statistic. This is useful in a finance dashboard where each statistic represents the expenses of a category and can now display an image. For example, if you group stores like Jumbo or Plus into a category, you can now show their logos instead of a generic icon.

**Things I've done**
- [x] The `image-src` and `image-alt` props have been added.
- [x] The `icon` prop has been made optional.
- [x] Added SCSS for the image.
- [x] Updated the documentation.