### PR TITLE
docs: add missing documentation for components, composables and API

### DIFF
--- a/docs/.vitepress/component-navigation.ts
+++ b/docs/.vitepress/component-navigation.ts
@@ -6,6 +6,7 @@ const navigation: SidebarItem = {
         {text: 'Action', link: '/guide/components/action', image: '/assets/components/action.svg'},
         {text: 'Action bar', link: '/guide/components/action-bar'},
         {text: 'Action pane', link: '/guide/components/action-pane'},
+        {text: 'Actions', link: '/guide/components/actions'},
         {
             text: 'Attention',
             link: '/guide/components/attention/',
@@ -111,6 +112,7 @@ const navigation: SidebarItem = {
                 {text: 'Row', link: '/guide/components/form/row'},
                 {text: 'Checkbox', link: '/guide/components/form/checkbox'},
                 {text: 'Date', link: '/guide/components/form/date'},
+                {text: 'Date range', link: '/guide/components/form/date-range'},
                 {text: 'Date time', link: '/guide/components/form/date-time'},
                 {
                     text: 'Field',
@@ -254,6 +256,7 @@ const navigation: SidebarItem = {
         {text: 'Percentage bar', link: '/guide/components/percentage-bar'},
         {text: 'Persona', link: '/guide/components/persona'},
         {text: 'Placeholder', link: '/guide/components/placeholder'},
+        {text: 'Pressable', link: '/guide/components/pressable'},
         {text: 'Progress bar', link: '/guide/components/progress-bar'},
         {text: 'Remove', link: '/guide/components/remove', image: '/assets/components/remove.svg'},
         {text: 'Root', link: '/guide/components/root'},

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -78,6 +78,8 @@ export default defineConfig({
                 items: [
                     {text: 'Introduction', link: '/guide/introduction/what-is-flux'},
                     {text: 'Components', link: '/guide/components/'},
+                    {text: 'Composables', link: '/guide/composables/useBreakpoints'},
+                    {text: 'API', link: '/guide/api/fluxRegisterIcons'},
                     {text: 'Transitions', link: '/guide/transitions/breakthrough'}
                 ]
             },
@@ -134,6 +136,30 @@ export default defineConfig({
                 },
                 componentNavigation,
                 {
+                    text: 'Composables',
+                    collapsed: false,
+                    items: [
+                        {text: 'useBreakpoints', link: '/guide/composables/useBreakpoints'},
+                        {text: 'useDisabled', link: '/guide/composables/useDisabled'},
+                        {text: 'useDisabledInjection', link: '/guide/composables/useDisabledInjection'},
+                        {text: 'useExpandableGroupInjection', link: '/guide/composables/useExpandableGroupInjection'},
+                        {text: 'useFilterInjection', link: '/guide/composables/useFilterInjection'},
+                        {text: 'useFlyoutInjection', link: '/guide/composables/useFlyoutInjection'},
+                        {text: 'useFormFieldInjection', link: '/guide/composables/useFormFieldInjection'},
+                        {text: 'useTableInjection', link: '/guide/composables/useTableInjection'},
+                        {text: 'useTooltipInjection', link: '/guide/composables/useTooltipInjection'}
+                    ]
+                },
+                {
+                    text: 'API',
+                    collapsed: false,
+                    items: [
+                        {text: 'fluxRegisterIcons', link: '/guide/api/fluxRegisterIcons'},
+                        {text: 'useFluxStore', link: '/guide/api/useFluxStore'},
+                        {text: 'Helpers', link: '/guide/api/helpers'}
+                    ]
+                },
+                {
                     text: 'Transitions',
                     collapsed: false,
                     items: [
@@ -168,6 +194,13 @@ export default defineConfig({
                         {text: 'Navigation', link: '/dashboard/components/navigation'},
                         {text: 'Side', link: '/dashboard/components/side'}
                     ]
+                },
+                {
+                    text: 'Composables',
+                    collapsed: false,
+                    items: [
+                        {text: 'useDashboardInjection', link: '/dashboard/composables/useDashboardInjection'}
+                    ]
                 }
             ],
             '/statistics/': [
@@ -176,7 +209,8 @@ export default defineConfig({
                     collapsed: false,
                     items: [
                         {text: 'What is Flux Statistics?', link: '/statistics/'},
-                        {text: 'Installation', link: '/statistics/introduction/installation'}
+                        {text: 'Installation', link: '/statistics/introduction/installation'},
+                        {text: 'Chart colors', link: '/statistics/introduction/colors'}
                     ]
                 },
                 {
@@ -242,7 +276,8 @@ export default defineConfig({
                         {text: 'useFocusTrapSubscription', link: '/internals/composables/useFocusTrapSubscription'},
                         {text: 'useFocusZone', link: '/internals/composables/useFocusZone'},
                         {text: 'useInView', link: '/internals/composables/useInView'},
-                        {text: 'useRemembered', link: '/internals/composables/useRemembered'}
+                        {text: 'useRemembered', link: '/internals/composables/useRemembered'},
+                        {text: 'useScrollPosition', link: '/internals/composables/useScrollPosition'}
                     ]
                 },
                 {
@@ -266,7 +301,17 @@ export default defineConfig({
                         {text: 'getFocusableElement', link: '/internals/utils/getFocusableElement'},
                         {text: 'getFocusableElements', link: '/internals/utils/getFocusableElements'},
                         {text: 'getKeyboardFocusableElements', link: '/internals/utils/getKeyboardFocusableElements'},
-                        {text: 'unrefTemplateElement', link: '/internals/utils/unrefTemplateElement'}
+                        {text: 'unrefTemplateElement', link: '/internals/utils/unrefTemplateElement'},
+                        {text: 'warn', link: '/internals/utils/warn'},
+                        {text: 'wrapFocus', link: '/internals/utils/wrapFocus'},
+                        {text: 'FOCUS_TRAP_LOCKS', link: '/internals/utils/focusTrap'}
+                    ]
+                },
+                {
+                    text: 'Data',
+                    collapsed: false,
+                    items: [
+                        {text: 'Color palette', link: '/internals/data/color'}
                     ]
                 }
             ],

--- a/docs/code/guide/components/form/date-range/basic.vue
+++ b/docs/code/guide/components/form/date-range/basic.vue
@@ -1,0 +1,21 @@
+<template>
+    <FluxPane style="max-width: 390px">
+        <FluxForm>
+            <FluxPaneBody>
+                <FluxFormField label="Period">
+                    <FluxFormDateRangeInput v-model="value"/>
+                </FluxFormField>
+            </FluxPaneBody>
+        </FluxForm>
+    </FluxPane>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxForm, FluxFormDateRangeInput, FluxFormField, FluxPane, FluxPaneBody } from '@flux-ui/components';
+    import { DateTime } from 'luxon';
+    import { ref } from 'vue';
+
+    const value = ref<[DateTime, DateTime] | null>(null);
+</script>

--- a/docs/code/guide/components/form/date-range/preview.vue
+++ b/docs/code/guide/components/form/date-range/preview.vue
@@ -1,0 +1,26 @@
+<template>
+    <Preview>
+        <FluxPane style="max-width: 390px">
+            <FluxForm>
+                <FluxPaneBody>
+                    <FluxFormField label="Period">
+                        <FluxFormDateRangeInput v-model="value"/>
+                    </FluxFormField>
+                </FluxPaneBody>
+            </FluxForm>
+        </FluxPane>
+    </Preview>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxForm, FluxFormDateRangeInput, FluxFormField, FluxPane, FluxPaneBody } from '@flux-ui/components';
+    import { DateTime } from 'luxon';
+    import { ref } from 'vue';
+
+    const value = ref<[DateTime, DateTime] | null>([
+        DateTime.now().startOf('month'),
+        DateTime.now().endOf('month')
+    ]);
+</script>

--- a/docs/code/guide/components/form/date-range/week.vue
+++ b/docs/code/guide/components/form/date-range/week.vue
@@ -1,0 +1,23 @@
+<template>
+    <FluxPane style="max-width: 390px">
+        <FluxForm>
+            <FluxPaneBody>
+                <FluxFormField label="Week">
+                    <FluxFormDateRangeInput
+                        v-model="value"
+                        range-mode="week"/>
+                </FluxFormField>
+            </FluxPaneBody>
+        </FluxForm>
+    </FluxPane>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxForm, FluxFormDateRangeInput, FluxFormField, FluxPane, FluxPaneBody } from '@flux-ui/components';
+    import { DateTime } from 'luxon';
+    import { ref } from 'vue';
+
+    const value = ref<[DateTime, DateTime] | null>(null);
+</script>

--- a/docs/code/guide/components/pressable/basic.vue
+++ b/docs/code/guide/components/pressable/basic.vue
@@ -1,0 +1,33 @@
+<template>
+    <FluxStack direction="horizontal">
+        <FluxPressable
+            component-type="button"
+            @click="clicks++">
+            <FluxPane>
+                <FluxPaneBody>
+                    Button ({{ clicks }} clicks)
+                </FluxPaneBody>
+            </FluxPane>
+        </FluxPressable>
+
+        <FluxPressable
+            component-type="link"
+            href="https://flux.bas.dev"
+            target="_blank">
+            <FluxPane>
+                <FluxPaneBody>
+                    External link
+                </FluxPaneBody>
+            </FluxPane>
+        </FluxPressable>
+    </FluxStack>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxPane, FluxPaneBody, FluxPressable, FluxStack } from '@flux-ui/components';
+    import { ref } from 'vue';
+
+    const clicks = ref(0);
+</script>

--- a/docs/code/guide/components/pressable/preview.vue
+++ b/docs/code/guide/components/pressable/preview.vue
@@ -1,0 +1,35 @@
+<template>
+    <Preview>
+        <FluxStack direction="horizontal">
+            <FluxPressable
+                component-type="button"
+                @click="clicks++">
+                <FluxPane>
+                    <FluxPaneBody>
+                        Button ({{ clicks }} clicks)
+                    </FluxPaneBody>
+                </FluxPane>
+            </FluxPressable>
+
+            <FluxPressable
+                component-type="link"
+                href="https://flux.bas.dev"
+                target="_blank">
+                <FluxPane>
+                    <FluxPaneBody>
+                        External link
+                    </FluxPaneBody>
+                </FluxPane>
+            </FluxPressable>
+        </FluxStack>
+    </Preview>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxPane, FluxPaneBody, FluxPressable, FluxStack } from '@flux-ui/components';
+    import { ref } from 'vue';
+
+    const clicks = ref(0);
+</script>

--- a/docs/dashboard/composables/useDashboardInjection.md
+++ b/docs/dashboard/composables/useDashboardInjection.md
@@ -1,0 +1,28 @@
+# useDashboardInjection
+
+This composable provides access to the [Dashboard](../components/dashboard) context. It must be used within a FluxDashboard component tree.
+
+::: warning
+This composable will throw an error if used outside of a FluxDashboard component.
+:::
+
+## Usage
+
+```ts
+import { useDashboardInjection } from '@flux-ui/dashboard';
+
+const dashboard = useDashboardInjection();
+```
+
+## Type declarations
+
+```ts
+declare function useDashboardInjection(): FluxDashboardInjection;
+```
+
+## Used by
+
+- [Dashboard content](../components/content)
+- [Dashboard header](../components/header)
+- [Dashboard navigation](../components/navigation)
+- [Dashboard side](../components/side)

--- a/docs/guide/api/fluxRegisterIcons.md
+++ b/docs/guide/api/fluxRegisterIcons.md
@@ -1,0 +1,35 @@
+# fluxRegisterIcons
+
+Registers FontAwesome icon definitions into the internal Flux icon registry. This function must be called during your application setup to make icons available to Flux components.
+
+## Usage
+
+```ts
+import { fluxRegisterIcons } from '@flux-ui/components';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+
+// Register all solid icons
+fluxRegisterIcons(fas);
+```
+
+```ts
+import { fluxRegisterIcons } from '@flux-ui/components';
+import { faCheck, faXmark, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+
+// Register specific icons
+fluxRegisterIcons({ faCheck, faXmark, faChevronDown });
+```
+
+## Type declarations
+
+```ts
+import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+
+type Icons = Record<string, IconDefinition>;
+
+declare function fluxRegisterIcons(icons: Icons): void;
+```
+
+::: tip
+For more information about configuring icons, see the [Font Awesome](../introduction/font-awesome) guide.
+:::

--- a/docs/guide/api/helpers.md
+++ b/docs/guide/api/helpers.md
@@ -1,0 +1,35 @@
+# Helper functions
+
+Utility type guards for working with form select data structures.
+
+## isFluxFormSelectGroup
+
+Checks if a given item is a [Form select](../components/form/select/) group.
+
+```ts
+import { isFluxFormSelectGroup } from '@flux-ui/components';
+
+if (isFluxFormSelectGroup(item)) {
+    console.log('This is a group with children:', item.label);
+}
+```
+
+## isFluxFormSelectOption
+
+Checks if a given item is a [Form select](../components/form/select/) option.
+
+```ts
+import { isFluxFormSelectOption } from '@flux-ui/components';
+
+if (isFluxFormSelectOption(item)) {
+    console.log('This is a selectable option with value:', item.value);
+}
+```
+
+## Type declarations
+
+```ts
+declare function isFluxFormSelectGroup(item: unknown): item is FluxFormSelectGroup;
+
+declare function isFluxFormSelectOption(item: unknown): item is FluxFormSelectOption;
+```

--- a/docs/guide/api/useFluxStore.md
+++ b/docs/guide/api/useFluxStore.md
@@ -1,0 +1,63 @@
+# useFluxStore
+
+Provides access to the centralized Flux store that manages dialogs, snackbars and tooltips. This composable is primarily used internally by Flux components, but can be useful for advanced use cases.
+
+## Usage
+
+```ts
+import { useFluxStore } from '@flux-ui/components';
+
+const store = useFluxStore();
+
+// Check if any dialogs are open
+if (store.inertMain.value) {
+    console.log('A dialog is currently blocking the main content.');
+}
+```
+
+## Type declarations
+
+```ts
+import type { ComputedRef } from 'vue';
+
+declare function useFluxStore(): FluxStore;
+
+interface FluxStore {
+    readonly alerts: FluxAlertObject[];
+    readonly confirms: FluxConfirmObject[];
+    readonly prompts: FluxPromptObject[];
+    readonly snackbars: FluxSnackbarObject[];
+    readonly tooltips: FluxTooltipObject[];
+
+    readonly dialogCount: number;
+    readonly inertMain: ComputedRef<boolean>;
+    readonly tooltip: ComputedRef<FluxTooltipObject | null>;
+
+    addAlert(spec: Omit<FluxAlertObject, 'id'>): number;
+    addConfirm(spec: Omit<FluxConfirmObject, 'id'>): number;
+    addPrompt(spec: Omit<FluxPromptObject, 'id'>): number;
+    addSnackbar(spec: Omit<FluxSnackbarObject, 'id'>): number;
+    addTooltip(spec: Omit<FluxTooltipObject, 'id'>): number;
+
+    removeAlert(id: number): void;
+    removeConfirm(id: number): void;
+    removePrompt(id: number): void;
+    removeSnackbar(id: number): void;
+    removeTooltip(id: number): void;
+
+    updateSnackbar(id: number, spec: Partial<FluxSnackbarObject>): void;
+    updateTooltip(id: number, spec: Partial<FluxTooltipObject>): void;
+
+    registerDialog(): [number, VoidFunction];
+
+    showAlert(spec: Omit<FluxAlertObject, 'id' | 'onClose'>): Promise<void>;
+    showConfirm(spec: Omit<FluxConfirmObject, 'id' | 'onCancel' | 'onConfirm'>): Promise<boolean>;
+    showPrompt(spec: Omit<FluxPromptObject, 'id' | 'onCancel' | 'onConfirm'>): Promise<string | false>;
+    showSnackbar(spec: Omit<FluxSnackbarObject, 'id'> & { duration?: number }): Promise<void>;
+    showSnackbarSync(spec: Omit<FluxSnackbarObject, 'id'> & { duration?: number }): void;
+}
+```
+
+::: tip
+For showing dialogs and snackbars, prefer using the dedicated functions [showAlert](../components/attention/alert), [showConfirm](../components/attention/confirm), [showPrompt](../components/attention/prompt) and [showSnackbar](../components/attention/snackbar) instead of interacting with the store directly.
+:::

--- a/docs/guide/components/actions.md
+++ b/docs/guide/components/actions.md
@@ -1,0 +1,35 @@
+---
+outline: deep
+
+slots:
+    -   name: default
+        description: The action buttons or other interactive elements to display.
+---
+
+# Actions
+
+Actions is a horizontal container for action buttons with built-in keyboard navigation. It uses a focus zone to enable arrow key navigation between child elements, making it accessible for keyboard users.
+
+<FrontmatterDocs/>
+
+## Snippet
+
+```vue
+<template>
+    <FluxActions>
+        <FluxPrimaryButton label="Save"/>
+        <FluxSecondaryButton label="Cancel"/>
+        <FluxDestructiveButton label="Delete"/>
+    </FluxActions>
+</template>
+
+<script
+    setup
+    lang="ts">
+    import { FluxActions, FluxPrimaryButton, FluxSecondaryButton, FluxDestructiveButton } from '@flux-ui/components';
+</script>
+```
+
+## Used components
+
+- [Stack](./layout/stack/)

--- a/docs/guide/components/form/date-range.md
+++ b/docs/guide/components/form/date-range.md
@@ -1,0 +1,83 @@
+---
+outline: deep
+
+props:
+    -   name: auto-complete
+        description: The autocomplete attribute for the underlying input.
+        type: FluxAutoCompleteType
+        optional: true
+
+    -   name: auto-focus
+        description: Automatically focuses the input when mounted.
+        type: boolean
+        optional: true
+
+    -   name: disabled
+        description: Disables the input.
+        type: boolean
+        optional: true
+
+    -   name: is-readonly
+        description: Makes the input read-only.
+        type: boolean
+        optional: true
+
+    -   name: max
+        description: The maximum selectable date.
+        type: DateTime
+        optional: true
+
+    -   name: min
+        description: The minimum selectable date.
+        type: DateTime
+        optional: true
+
+    -   name: placeholder
+        description: The placeholder text when no date range is selected.
+        type: string
+        optional: true
+
+    -   name: range-mode
+        description: The range selection mode.
+        type: "'range' | 'week' | 'month'"
+        default: "'range'"
+        optional: true
+
+requiredIcons:
+    - calendar
+---
+
+# Date range
+
+A date range picker that allows users to select a start and end date. It displays a formatted label of the selected date range and opens a calendar flyout when clicked. The `v-model` value is a tuple of two Luxon `DateTime` objects or `null`.
+
+::: render
+render=../../../code/guide/components/form/date-range/preview.vue
+:::
+
+<FrontmatterDocs/>
+
+## Examples
+
+::: example Basic || A basic date range input.
+example=../../../code/guide/components/form/date-range/basic.vue
+:::
+
+::: example Week mode || A date range input that selects entire weeks.
+example=../../../code/guide/components/form/date-range/week.vue
+:::
+
+## Range modes
+
+The `range-mode` prop controls how the date range is selected:
+
+- **range** (default) — Free selection of start and end date.
+- **week** — Selects an entire week at once.
+- **month** — Selects an entire month at once.
+
+## Used components
+
+- [Date picker](../date-picker)
+- [Flyout](../flyout)
+- [Form input group](./input/group)
+- [Secondary button](../button/secondary)

--- a/docs/guide/components/pressable.md
+++ b/docs/guide/components/pressable.md
@@ -1,0 +1,95 @@
+---
+outline: deep
+
+emits:
+    -   name: click
+        description: Triggered when the element is clicked.
+        type: [ MouseEvent ]
+
+    -   name: mouseenter
+        description: Triggered when the mouse enters the element.
+        type: [ MouseEvent ]
+
+    -   name: mouseleave
+        description: Triggered when the mouse leaves the element.
+        type: [ MouseEvent ]
+
+props:
+    -   name: component-type
+        description: Determines which HTML element or component is rendered.
+        type: "'route' | 'link' | 'button' | 'div'"
+        optional: true
+
+    -   name: href
+        description: URL for anchor elements. Used when component-type is 'link'.
+        type: string
+        optional: true
+
+    -   name: rel
+        description: The rel attribute for link elements.
+        type: string
+        optional: true
+
+    -   name: target
+        description: The target attribute for link elements.
+        type: string
+        optional: true
+
+    -   name: to
+        description: Vue Router navigation target. Used when component-type is 'route'.
+        type: FluxTo
+        optional: true
+
+slots:
+    -   name: default
+        description: The content of the pressable element.
+---
+
+# Pressable
+
+A polymorphic base component that renders as different element types based on the `component-type` prop. It can render as a Vue Router link, anchor tag, button, or div. This component is primarily used internally by other Flux components like [Button](./button/) to provide flexible navigation and interaction behavior.
+
+::: render
+render=../../code/guide/components/pressable/preview.vue
+:::
+
+<FrontmatterDocs/>
+
+## Examples
+
+::: example Basic || Different component types rendered side by side.
+example=../../code/guide/components/pressable/basic.vue
+:::
+
+## Component types
+
+| Type | Renders as | Use case |
+|------|-----------|----------|
+| `route` | `<router-link>` | Internal navigation with Vue Router |
+| `link` | `<a>` | External links |
+| `button` | `<button>` | Click actions |
+| `div` | `<div>` | Non-interactive wrapper |
+
+## Snippet
+
+```vue
+<template>
+    <FluxPressable
+        component-type="link"
+        href="https://example.com"
+        target="_blank"
+        @click="onClick">
+        Click me
+    </FluxPressable>
+</template>
+
+<script
+    setup
+    lang="ts">
+    import { FluxPressable } from '@flux-ui/components';
+
+    function onClick(evt: MouseEvent): void {
+        console.log('Clicked!', evt);
+    }
+</script>
+```

--- a/docs/guide/components/root.md
+++ b/docs/guide/components/root.md
@@ -14,6 +14,18 @@ Alerts, confirms and snackbars are all rendered here for example.
 
 <FrontmatterDocs/>
 
+## Providers
+
+FluxRoot internally renders the following provider components. These are not used directly, but are required for certain features to work:
+
+- **FluxOverlayProvider** — Renders stacked [alerts](./attention/alert), [confirms](./attention/confirm) and [prompts](./attention/prompt) from the global store.
+- **FluxSnackbarProvider** — Renders [snackbars](./attention/snackbar) with transition animations.
+- **FluxTooltipProvider** — Renders [tooltips](./tooltip) with intelligent positioning relative to their trigger element.
+
+::: tip
+These providers are automatically included when you use FluxRoot. You do not need to import or configure them separately.
+:::
+
 ## Snippet
 
 ```vue [App.vue]

--- a/docs/guide/components/slide-over.md
+++ b/docs/guide/components/slide-over.md
@@ -12,7 +12,7 @@ props:
         optional: true
 
     -   name: view-key
-        description: ??
+        description: A unique key to identify the current view within the slide over. Used for view-based transitions.
         type: string
         optional: true
 

--- a/docs/guide/components/stepper/step.md
+++ b/docs/guide/components/stepper/step.md
@@ -19,3 +19,26 @@ The stepper step represents an individual step within the stepper. It contains t
 <<< @/code/guide/components/stepper/step/snippet.vue [StepperStep.vue]
 
 :::
+
+## Usage
+
+Each step is placed inside a [Stepper steps](./steps) component. The step's content is only rendered when the corresponding step is active.
+
+```vue
+<FluxStepper v-model="currentStep">
+    <FluxStepperSteps>
+        <FluxStepperStep>
+            <p>Content for the first step.</p>
+        </FluxStepperStep>
+
+        <FluxStepperStep>
+            <p>Content for the second step.</p>
+        </FluxStepperStep>
+    </FluxStepperSteps>
+</FluxStepper>
+```
+
+## Used components
+
+- [Stepper](./index)
+- [Stepper steps](./steps)

--- a/docs/guide/composables/useBreakpoints.md
+++ b/docs/guide/composables/useBreakpoints.md
@@ -1,0 +1,41 @@
+# useBreakpoints
+
+This composable tracks the current viewport breakpoint and provides reactive boolean refs for each breakpoint size.
+
+## Usage
+
+```ts
+import { useBreakpoints } from '@flux-ui/components';
+
+const { currentBreakpoint, xs, sm, md, lg, xl } = useBreakpoints();
+
+// Use in a computed or watcher
+if (md.value) {
+    console.log('Viewport is at least medium');
+}
+```
+
+## Breakpoints
+
+| Name | Minimum width |
+|------|---------------|
+| `xs` | 0px |
+| `sm` | 640px |
+| `md` | 768px |
+| `lg` | 1024px |
+| `xl` | 1280px |
+
+## Type declarations
+
+```ts
+type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+declare function useBreakpoints(): {
+    readonly currentBreakpoint: Ref<Breakpoint | null>;
+    readonly xs: Ref<boolean>;
+    readonly sm: Ref<boolean>;
+    readonly md: Ref<boolean>;
+    readonly lg: Ref<boolean>;
+    readonly xl: Ref<boolean>;
+};
+```

--- a/docs/guide/composables/useDisabled.md
+++ b/docs/guide/composables/useDisabled.md
@@ -1,0 +1,32 @@
+# useDisabled
+
+This composable merges a component's local disabled state with any inherited disabled state from a parent [Disabled](../components/disabled) component. Returns `true` if either the component itself or any parent in the tree is disabled.
+
+## Usage
+
+```ts
+import { useDisabled } from '@flux-ui/components';
+import { toRef } from 'vue';
+
+const { disabled: componentDisabled } = defineProps<{
+    disabled?: boolean;
+}>();
+
+const disabled = useDisabled(toRef(() => componentDisabled));
+```
+
+## Type declarations
+
+```ts
+import type { ComputedRef, Ref } from 'vue';
+
+declare function useDisabled(
+    componentDisabled: Ref<boolean>
+): ComputedRef<boolean>;
+```
+
+## Used by
+
+- [Button](../components/button/)
+- [Form input](../components/form/input/)
+- [Form select](../components/form/select/)

--- a/docs/guide/composables/useDisabledInjection.md
+++ b/docs/guide/composables/useDisabledInjection.md
@@ -1,0 +1,23 @@
+# useDisabledInjection
+
+This composable retrieves the disabled state from a parent [Disabled](../components/disabled) component via Vue's dependency injection. Returns `false` when no parent provides a disabled state.
+
+## Usage
+
+```ts
+import { useDisabledInjection } from '@flux-ui/components';
+
+const isTreeDisabled = useDisabledInjection();
+```
+
+## Type declarations
+
+```ts
+import type { Ref } from 'vue';
+
+declare function useDisabledInjection(): Ref<boolean>;
+```
+
+## Used by
+
+- [useDisabled](./useDisabled)

--- a/docs/guide/composables/useExpandableGroupInjection.md
+++ b/docs/guide/composables/useExpandableGroupInjection.md
@@ -1,0 +1,25 @@
+# useExpandableGroupInjection
+
+This composable provides access to the [Expandable group](../components/expandable/group) context. It allows child expandable items to register with the group and respond to group-level actions like closing all items.
+
+## Usage
+
+```ts
+import { useExpandableGroupInjection } from '@flux-ui/components';
+
+const { closeAll, register, unregister } = useExpandableGroupInjection();
+```
+
+## Type declarations
+
+```ts
+declare function useExpandableGroupInjection(): {
+    closeAll(): void;
+    register(uid: number, instance: object): void;
+    unregister(uid: number): void;
+};
+```
+
+## Used by
+
+- [Expandable](../components/expandable/)

--- a/docs/guide/composables/useFilterInjection.md
+++ b/docs/guide/composables/useFilterInjection.md
@@ -1,0 +1,33 @@
+# useFilterInjection
+
+This composable provides access to the [Filter](../components/filter/) context. It is used by filter sub-components to interact with the parent filter's state and actions.
+
+## Usage
+
+```ts
+import { useFilterInjection } from '@flux-ui/components';
+
+const { state, back, reset, getValue, hasValue, setValue } = useFilterInjection();
+```
+
+## Type declarations
+
+```ts
+import type { Ref } from 'vue';
+
+declare function useFilterInjection(): {
+    readonly state: Ref<object>;
+    back(): void;
+    reset(): void;
+    getValue(): unknown;
+    hasValue(): boolean;
+    setValue(value: unknown): void;
+};
+```
+
+## Used by
+
+- [Filter date](../components/filter/date)
+- [Filter option](../components/filter/option)
+- [Filter options](../components/filter/options)
+- [Filter range](../components/filter/range)

--- a/docs/guide/composables/useFlyoutInjection.md
+++ b/docs/guide/composables/useFlyoutInjection.md
@@ -1,0 +1,28 @@
+# useFlyoutInjection
+
+This composable provides access to the [Flyout](../components/flyout) state. It allows child components to react to the flyout's open, opening and closing states.
+
+## Usage
+
+```ts
+import { useFlyoutInjection } from '@flux-ui/components';
+
+const { isClosing, isOpen, isOpening } = useFlyoutInjection();
+```
+
+## Type declarations
+
+```ts
+import type { Ref } from 'vue';
+
+declare function useFlyoutInjection(): {
+    readonly isClosing: Ref<boolean>;
+    readonly isOpen: Ref<boolean>;
+    readonly isOpening: Ref<boolean>;
+};
+```
+
+## Used by
+
+- [Flyout](../components/flyout)
+- [Menu](../components/menu/)

--- a/docs/guide/composables/useFormFieldInjection.md
+++ b/docs/guide/composables/useFormFieldInjection.md
@@ -1,0 +1,25 @@
+# useFormFieldInjection
+
+This composable provides access to the [Form field](../components/form/field/) context. It supplies a unique ID that can be used for `for`/`id` attribute pairing between labels and inputs.
+
+## Usage
+
+```ts
+import { useFormFieldInjection } from '@flux-ui/components';
+
+const { id } = useFormFieldInjection();
+```
+
+## Type declarations
+
+```ts
+declare function useFormFieldInjection(): {
+    readonly id: string;
+};
+```
+
+## Used by
+
+- [Form input](../components/form/input/)
+- [Form select](../components/form/select/)
+- [Form text area](../components/form/text-area)

--- a/docs/guide/composables/useTableInjection.md
+++ b/docs/guide/composables/useTableInjection.md
@@ -1,0 +1,28 @@
+# useTableInjection
+
+This composable provides access to the [Table](../components/table/) styling context. It supplies configuration flags that determine the table's visual appearance.
+
+## Usage
+
+```ts
+import { useTableInjection } from '@flux-ui/components';
+
+const { isBordered, isHoverable, isSeparated, isStriped } = useTableInjection();
+```
+
+## Type declarations
+
+```ts
+declare function useTableInjection(): {
+    readonly isBordered: boolean;
+    readonly isHoverable: boolean;
+    readonly isSeparated: boolean;
+    readonly isStriped: boolean;
+};
+```
+
+## Used by
+
+- [Table row](../components/table/row)
+- [Table cell](../components/table/cell)
+- [Table header](../components/table/header)

--- a/docs/guide/composables/useTooltipInjection.md
+++ b/docs/guide/composables/useTooltipInjection.md
@@ -1,0 +1,26 @@
+# useTooltipInjection
+
+This composable provides access to the [Tooltip](../components/tooltip) provider context. It exposes a `calculate` method that triggers tooltip position recalculation.
+
+## Usage
+
+```ts
+import { useTooltipInjection } from '@flux-ui/components';
+
+const { calculate } = useTooltipInjection();
+
+// Trigger position recalculation
+calculate();
+```
+
+## Type declarations
+
+```ts
+declare function useTooltipInjection(): {
+    calculate(): void;
+};
+```
+
+## Used by
+
+- [Tooltip](../components/tooltip)

--- a/docs/internals/composables/useScrollPosition.md
+++ b/docs/internals/composables/useScrollPosition.md
@@ -1,0 +1,37 @@
+# useScrollPosition
+
+This composable tracks the scroll position of a given element or the document. It provides reactive `x` and `y` refs that update on scroll events.
+
+## Usage
+
+```ts
+import { useScrollPosition } from '@flux-ui/internals';
+import { useTemplateRef } from 'vue';
+
+// Track document scroll
+const { x, y } = useScrollPosition();
+
+// Track element scroll
+const element = useTemplateRef('scrollContainer');
+const { x: elX, y: elY } = useScrollPosition(element);
+```
+
+## Type declarations
+
+```ts
+import type { TemplateRef } from '@flux-ui/internals';
+import type { Ref } from 'vue';
+
+export declare function useScrollPosition<TElement extends HTMLElement>(
+    elementRef?: TemplateRef<TElement>
+): UseScrollPositionReturn;
+
+type UseScrollPositionReturn = {
+    readonly x: Ref<number>;
+    readonly y: Ref<number>;
+};
+```
+
+## Used by
+
+- [Dashboard](../../dashboard/components/dashboard)

--- a/docs/internals/data/color.md
+++ b/docs/internals/data/color.md
@@ -1,0 +1,49 @@
+# Color palette
+
+The `@flux-ui/internals` package exports a comprehensive color palette based on the Tailwind CSS color system. Each color is available in 12 shades, from `50` (lightest) to `950` (darkest).
+
+## Usage
+
+```ts
+import { blue500, red500, green500 } from '@flux-ui/internals';
+
+console.log(blue500); // '#3b82f6'
+```
+
+## Available colors
+
+Each of the following colors exports shades `50`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`, and `950`:
+
+| Color | Example (500) |
+|-------|---------------|
+| `slate` | `#64748b` |
+| `gray` | `#6b7280` |
+| `zinc` | `#71717a` |
+| `neutral` | `#737373` |
+| `stone` | `#78716c` |
+| `red` | `#ef4444` |
+| `orange` | `#f97316` |
+| `amber` | `#f59e0b` |
+| `yellow` | `#eab308` |
+| `lime` | `#84cc16` |
+| `green` | `#22c55e` |
+| `emerald` | `#10b981` |
+| `teal` | `#14b8a6` |
+| `cyan` | `#06b6d4` |
+| `sky` | `#0ea5e9` |
+| `blue` | `#3b82f6` |
+| `indigo` | `#6366f1` |
+| `violet` | `#8b5cf6` |
+| `purple` | `#a855f7` |
+| `fuchsia` | `#d946ef` |
+| `pink` | `#ec4899` |
+| `rose` | `#f43f5e` |
+
+## Type declarations
+
+```ts
+// Each color exports shades as string constants, e.g.:
+export declare const blue50: string;
+export declare const blue100: string;
+// ... through blue950
+```

--- a/docs/internals/utils/focusTrap.md
+++ b/docs/internals/utils/focusTrap.md
@@ -1,0 +1,59 @@
+# FOCUS_TRAP_LOCKS
+
+A stack-based focus trap manager. Maintains a LIFO (Last In, First Out) stack of focus traps. When a new trap is pushed, the previous one is disabled. When a trap is removed, the previous one is re-enabled.
+
+## Usage
+
+```ts
+import { FOCUS_TRAP_LOCKS } from '@flux-ui/internals';
+
+// Add a focus trap
+FOCUS_TRAP_LOCKS.add('my-trap', (isEnabled) => {
+    console.log('Trap enabled:', isEnabled);
+});
+
+// Check if a trap is currently active
+if (FOCUS_TRAP_LOCKS.active) {
+    console.log('Current trap:', FOCUS_TRAP_LOCKS.current);
+}
+
+// Subscribe to changes
+const unsubscribe = FOCUS_TRAP_LOCKS.subscribe((isEnabled, focusTraps) => {
+    console.log('Focus traps changed:', focusTraps);
+});
+
+// Remove the trap
+FOCUS_TRAP_LOCKS.remove('my-trap');
+
+// Cleanup subscription
+unsubscribe();
+```
+
+## Type declarations
+
+```ts
+declare const FOCUS_TRAP_LOCKS: FocusTrapLockStack;
+
+interface FocusTrap {
+    id: string;
+    isEnabled: boolean;
+    setEnabled(isEnabled: boolean): void;
+}
+
+type FocusTrapListener = (isEnabled: boolean, focusTraps: FocusTrap[]) => void;
+
+declare class FocusTrapLockStack {
+    get active(): boolean;
+    get current(): FocusTrap | null;
+    add(id: string, setEnabled: Function, autoFocus?: boolean): void;
+    remove(id: string): void;
+    emit(): void;
+    subscribe(listener: FocusTrapListener): () => void;
+}
+```
+
+## Used by
+
+- [useFocusTrap](../composables/useFocusTrap)
+- [useFocusTrapLock](../composables/useFocusTrapLock)
+- [useFocusTrapSubscription](../composables/useFocusTrapSubscription)

--- a/docs/internals/utils/warn.md
+++ b/docs/internals/utils/warn.md
@@ -1,0 +1,17 @@
+# warn
+
+Logs a console warning prefixed with `[Flux]`. Used internally to notify developers of potential issues or misuse of components.
+
+## Usage
+
+```ts
+import { warn } from '@flux-ui/internals';
+
+warn('Component requires a parent FluxRoot.');
+```
+
+## Type declarations
+
+```ts
+declare function warn(...data: any[]): void;
+```

--- a/docs/internals/utils/wrapFocus.md
+++ b/docs/internals/utils/wrapFocus.md
@@ -1,0 +1,29 @@
+# wrapFocus
+
+Wraps focus within a container element, enabling circular focus navigation. When focus leaves the container, it wraps to the first or last focusable child based on the direction of navigation.
+
+## Usage
+
+```ts
+import { wrapFocus } from '@flux-ui/internals';
+
+// Wrap focus within a container
+wrapFocus(containerElement, targetElement);
+
+// Force focus to the first focusable element
+wrapFocus(containerElement, targetElement, true);
+```
+
+## Type declarations
+
+```ts
+declare function wrapFocus(
+    elm: HTMLElement,
+    targetElm: Element,
+    forceFirst?: boolean
+): void;
+```
+
+## Used by
+
+- [useFocusTrap](../composables/useFocusTrap)

--- a/docs/statistics/introduction/colors.md
+++ b/docs/statistics/introduction/colors.md
@@ -1,0 +1,41 @@
+# Chart colors
+
+Flux Statistics provides two pre-defined color palettes for use in charts.
+
+## CHART_COLORS
+
+A set of four CSS custom properties designed for themed chart colors. These colors adapt to the current theme.
+
+```ts
+import { CHART_COLORS } from '@flux-ui/statistics';
+
+// ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)']
+```
+
+## CHART_COLORFUL_COLORS
+
+A vibrant palette of 17 colors spanning the full spectrum. These are fixed hex color values from the Flux color system.
+
+```ts
+import { CHART_COLORFUL_COLORS } from '@flux-ui/statistics';
+
+// [red500, orange500, amber500, yellow500, lime500, green500, emerald500,
+//  teal500, cyan500, sky500, blue500, indigo500, violet500, purple500,
+//  fuchsia500, pink500, rose50]
+```
+
+## Usage
+
+```vue
+<template>
+    <FluxStatisticsBarChart
+        :data="chartData"
+        :colors="CHART_COLORFUL_COLORS"/>
+</template>
+
+<script
+    setup
+    lang="ts">
+    import { CHART_COLORFUL_COLORS } from '@flux-ui/statistics';
+</script>
+```


### PR DESCRIPTION
## Summary                
  - Add documentation for 6 undocumented exported components (FluxActions, FluxFormDateRangeInput, FluxPressable, and providers in Root)                                          
  - Add documentation for 10 exported composables (useBreakpoints, useDisabled, injection composables)                                                                            
  - Add documentation for API functions (fluxRegisterIcons, useFluxStore, helpers)                                                                                                
  - Add documentation for internals (useScrollPosition, warn, wrapFocus, FOCUS_TRAP_LOCKS, color palette)
  - Add chart colors documentation for statistics package
  - Fix quality issues in existing docs (slide-over placeholder, stepper/step examples)
  - Update VitePress sidebar navigation with new Composables, API and Data sections