### PR TITLE
fix: resolve bugs and code quality issues found in packages/components

### DIFF
--- a/packages/components/src/component/FluxBoxedIcon.vue
+++ b/packages/components/src/component/FluxBoxedIcon.vue
@@ -24,10 +24,6 @@
     import FluxIcon from './FluxIcon.vue';
     import $style from '$flux/css/component/Icon.module.scss';
 
-    defineEmits<{
-        click: [MouseEvent];
-    }>();
-
     defineProps<{
         readonly color?: FluxColor;
         readonly name: FluxIconName;

--- a/packages/components/src/component/FluxCalendar.vue
+++ b/packages/components/src/component/FluxCalendar.vue
@@ -103,6 +103,7 @@
                         <div :class="$style.calendarEvents">
                             <VNodeRenderer
                                 v-for="event of getEventsForDate(date)"
+                                :key="event.index"
                                 :class="clsx(
                                     event.type === 'single' && $style.isSingle,
                                     event.type === 'start' && $style.isStart,

--- a/packages/components/src/component/FluxChip.vue
+++ b/packages/components/src/component/FluxChip.vue
@@ -25,7 +25,7 @@
             v-if="iconTrailing"
             :name="iconTrailing"
             :size="16"/>
-    </component>
+    </Component>
 </template>
 
 <script

--- a/packages/components/src/component/FluxColorPicker.vue
+++ b/packages/components/src/component/FluxColorPicker.vue
@@ -205,7 +205,7 @@
         return computed({
             get: () => fromHSV?.(...unref(hsv))[index] ?? unref(hsv)[index],
             set: value => {
-                const values = fromHSV?.(...unref(hsv)) ?? unref(hsv);
+                const values: [number, number, number] = [...(fromHSV?.(...unref(hsv)) ?? unref(hsv))];
                 values[index] = value;
                 hsv.value = toHSV?.(...values) ?? values;
             }

--- a/packages/components/src/component/FluxColorSelect.vue
+++ b/packages/components/src/component/FluxColorSelect.vue
@@ -31,11 +31,11 @@
 
                 <FluxPaneBody :class="$style.colorSelectButtons">
                     <FluxSecondaryButton
-                        :label="t('flux.cancel')"
+                        :label="translate('flux.cancel')"
                         @click="close()"/>
 
                     <FluxPrimaryButton
-                        :label="t('flux.ok')"
+                        :label="translate('flux.ok')"
                         @click="select(customColor, close)"/>
                 </FluxPaneBody>
             </template>
@@ -68,7 +68,7 @@
         readonly isCustomAllowed?: boolean;
     }>();
 
-    const t = useTranslate();
+    const translate = useTranslate();
 
     const customColor = ref('#000000');
 

--- a/packages/components/src/component/FluxDatePicker.vue
+++ b/packages/components/src/component/FluxDatePicker.vue
@@ -136,7 +136,6 @@
     import $style from '$flux/css/component/DatePicker.module.scss';
 
     const modelValue = defineModel<DateTime | DateTime[] | null>({
-        default: null,
         required: true
     });
 

--- a/packages/components/src/component/FluxFader.vue
+++ b/packages/components/src/component/FluxFader.vue
@@ -48,13 +48,13 @@
     }
 
     function previous(): void {
-        current.value = unref(current) - 1 <= -1 ? unref(count) - 1 : unref(current) + 1;
+        current.value = unref(current) - 1 <= -1 ? unref(count) - 1 : unref(current) - 1;
     }
 
     watch(current, current => {
         const fader = unrefTemplateElement(faderRef);
 
-        if (!fader || fader.children.length === 0) {
+        if (!fader || fader.children.length === 0 || current < 0) {
             return;
         }
 

--- a/packages/components/src/component/FluxFocalPointEditor.vue
+++ b/packages/components/src/component/FluxFocalPointEditor.vue
@@ -112,11 +112,11 @@
         }
 
         const {top, left, width, height} = image.getBoundingClientRect();
-        const {pageX, pageY} = evt;
+        const {clientX, clientY} = evt;
 
         dragging.value = [
-            Math.max(0, Math.min(1, (pageX - left) / width)) * 100,
-            Math.max(0, Math.min(1, (pageY - top) / height)) * 100
+            Math.max(0, Math.min(1, (clientX - left) / width)) * 100,
+            Math.max(0, Math.min(1, (clientY - top) / height)) * 100
         ];
     }
 

--- a/packages/components/src/component/FluxFormDateRangeInput.vue
+++ b/packages/components/src/component/FluxFormDateRangeInput.vue
@@ -31,7 +31,6 @@
 <script
     lang="ts"
     setup>
-    import type { FluxAutoCompleteType } from '@flux-ui/types';
     import { clsx } from 'clsx';
     import type { DateTime } from 'luxon';
     import { computed, ref, toRef, unref, useTemplateRef, watch } from 'vue';
@@ -51,13 +50,9 @@
         disabled: componentDisabled,
         rangeMode = 'range'
     } = defineProps<{
-        readonly autoComplete?: FluxAutoCompleteType;
-        readonly autoFocus?: boolean;
         readonly disabled?: boolean;
-        readonly isReadonly?: boolean;
         readonly max?: DateTime;
         readonly min?: DateTime;
-        readonly placeholder?: string;
         readonly rangeMode?: 'range' | 'week' | 'month';
     }>();
 

--- a/packages/components/src/component/FluxFormDateTimeInput.vue
+++ b/packages/components/src/component/FluxFormDateTimeInput.vue
@@ -100,8 +100,8 @@
         const value: DateTime = (localValue.value ?? DateTime.now());
         localValue.value = value.set({
             hour: dateTime.hour,
-            minute: unref(isHourOnly) ? 0 : dateTime.minute,
-            second: unref(isHourOnly) ? 0 : dateTime.second
+            minute: isHourOnly ? 0 : dateTime.minute,
+            second: isHourOnly ? 0 : dateTime.second
         });
     }
 

--- a/packages/components/src/component/FluxFormSelect.vue
+++ b/packages/components/src/component/FluxFormSelect.vue
@@ -44,13 +44,13 @@
     const {groups, selected, values} = useFormSelect(modelValue, isMultiple, toRef(() => options), modelSearch);
 
     function onDeselect(id: string | number | null): void {
-        if (unref(isMultiple)) {
+        if (isMultiple) {
             modelValue.value = unref(values).filter(v => v !== id);
         }
     }
 
     function onSelect(id: string | number | null): void {
-        if (unref(isMultiple)) {
+        if (isMultiple) {
             modelValue.value = [...unref(values), id];
         } else {
             modelValue.value = id;

--- a/packages/components/src/component/FluxFormTextArea.vue
+++ b/packages/components/src/component/FluxFormTextArea.vue
@@ -7,6 +7,7 @@
         :autocomplete="autoComplete"
         :autofocus="autoFocus"
         :disabled="disabled"
+        :readonly="isReadonly"
         :maxlength="maxLength"
         :placeholder="placeholder"
         :style="{

--- a/packages/components/src/component/FluxQuantitySelector.vue
+++ b/packages/components/src/component/FluxQuantitySelector.vue
@@ -94,13 +94,10 @@
     }
 
     watchEffect(() => {
-        if (unref(modelValue) > max) {
-            increment();
-            return;
-        }
+        const value = unref(modelValue);
 
-        if (unref(modelValue) < min) {
-            decrement();
+        if (value > max || value < min) {
+            modelValue.value = Math.min(max, Math.max(min, value));
             return;
         }
 

--- a/packages/components/src/component/FluxSnackbar.vue
+++ b/packages/components/src/component/FluxSnackbar.vue
@@ -145,9 +145,11 @@
             return;
         }
 
-        let spec: Omit<FluxSnackbarObject, 'id'> = instance.props;
-        spec.onAction = onAction;
-        spec.onClose = onClose;
+        const spec: Omit<FluxSnackbarObject, 'id'> = {
+            ...instance.props,
+            onAction,
+            onClose
+        };
 
         id.value = addSnackbar(spec);
     }, {immediate: true});

--- a/packages/components/src/component/primitive/CoordinatePicker.vue
+++ b/packages/components/src/component/primitive/CoordinatePicker.vue
@@ -19,7 +19,7 @@
     setup>
     import { roundStep } from '@basmilius/utils';
     import { unrefTemplateElement } from '@flux-ui/internals';
-    import { computed, onMounted, onUnmounted, ref, toRef, unref, useTemplateRef, watch } from 'vue';
+    import { computed, ref, toRef, unref, useTemplateRef, watch } from 'vue';
     import { useDisabled } from '$flux/composable';
     import CoordinatePickerThumb from './CoordinatePickerThumb.vue';
     import $style from '$flux/css/component/primitive/CoordinatePicker.module.scss';
@@ -57,16 +57,6 @@
         (unref(modelValue)[0] - unref(min)[0]) / (unref(max)[0] - unref(min)[0]),
         (unref(modelValue)[1] - unref(min)[1]) / (unref(max)[1] - unref(min)[1])
     ]);
-
-    onMounted(() => {
-        document.addEventListener('pointermove', onPointerMove);
-        document.addEventListener('pointerup', onPointerUp, {passive: true});
-    });
-
-    onUnmounted(() => {
-        document.removeEventListener('pointermove', onPointerMove);
-        document.removeEventListener('pointerup', onPointerUp);
-    });
 
     function onDecrement(x: boolean, y: boolean): void {
         if (unref(disabled)) {
@@ -116,6 +106,8 @@
         }
 
         isDragging.value = true;
+        document.addEventListener('pointermove', onPointerMove);
+        document.addEventListener('pointerup', onPointerUp, {passive: true});
         requestAnimationFrame(() => onPointerMove(evt));
     }
 
@@ -149,6 +141,8 @@
 
     function onPointerUp(): void {
         isDragging.value = false;
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointerup', onPointerUp);
     }
 
     watch(isDragging, isDragging => emit('dragging', isDragging));

--- a/packages/components/src/component/primitive/CoordinatePicker.vue
+++ b/packages/components/src/component/primitive/CoordinatePicker.vue
@@ -19,7 +19,7 @@
     setup>
     import { roundStep } from '@basmilius/utils';
     import { unrefTemplateElement } from '@flux-ui/internals';
-    import { computed, ref, toRef, unref, useTemplateRef, watch } from 'vue';
+    import { computed, onUnmounted, ref, toRef, unref, useTemplateRef, watch } from 'vue';
     import { useDisabled } from '$flux/composable';
     import CoordinatePickerThumb from './CoordinatePickerThumb.vue';
     import $style from '$flux/css/component/primitive/CoordinatePicker.module.scss';
@@ -146,4 +146,9 @@
     }
 
     watch(isDragging, isDragging => emit('dragging', isDragging));
+
+    onUnmounted(() => {
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointerup', onPointerUp);
+    });
 </script>

--- a/packages/components/src/component/primitive/FilterItem.vue
+++ b/packages/components/src/component/primitive/FilterItem.vue
@@ -38,7 +38,7 @@
         emit('click', evt);
     }
 
-    watch(() => item, async () => {
+    watch([() => item, () => value], async () => {
         valueLabel.value = await unref(getValueLabel)(value) ?? undefined;
     }, {deep: true, immediate: true});
 </script>

--- a/packages/components/src/component/primitive/FilterItem.vue
+++ b/packages/components/src/component/primitive/FilterItem.vue
@@ -38,7 +38,16 @@
         emit('click', evt);
     }
 
-    watch([() => item, () => value], async () => {
-        valueLabel.value = await unref(getValueLabel)(value) ?? undefined;
+    watch([() => item, () => value], async ([, nextValue], _prev, onCleanup) => {
+        let cancelled = false;
+        onCleanup(() => {
+            cancelled = true;
+        });
+
+        const nextLabel = await unref(getValueLabel)(nextValue);
+
+        if (!cancelled) {
+            valueLabel.value = nextLabel ?? undefined;
+        }
     }, {deep: true, immediate: true});
 </script>

--- a/packages/components/src/component/primitive/SelectBase.vue
+++ b/packages/components/src/component/primitive/SelectBase.vue
@@ -286,8 +286,8 @@
                 return;
 
             default:
-                if (evt.key.match(/[a-z]/)) {
-                    highlightedIndex.value = unref(rawOptions).findIndex(o => o.label.toLowerCase().startsWith(evt.key));
+                if (evt.key.length === 1) {
+                    highlightedIndex.value = unref(rawOptions).findIndex(o => o.label.toLowerCase().startsWith(evt.key.toLowerCase()));
                 } else {
                     highlightedIndex.value = -1;
                 }

--- a/packages/components/src/component/primitive/SliderBase.vue
+++ b/packages/components/src/component/primitive/SliderBase.vue
@@ -22,7 +22,7 @@
     setup>
     import { unrefTemplateElement } from '@flux-ui/internals';
     import { clsx } from 'clsx';
-    import { onMounted, onUnmounted, toRef, unref, useTemplateRef, watch } from 'vue';
+    import { toRef, unref, useTemplateRef, watch } from 'vue';
     import { useDisabled } from '$flux/composable';
     import FluxTicks from '$flux/component/FluxTicks.vue';
     import $style from '$flux/css/component/primitive/Slider.module.scss';
@@ -47,22 +47,14 @@
     const disabled = useDisabled(toRef(() => componentDisabled));
     const rootRef = useTemplateRef('root');
 
-    onMounted(() => {
-        document.addEventListener('pointermove', onPointerMove);
-        document.addEventListener('pointerup', onPointerUp, {passive: true});
-    });
-
-    onUnmounted(() => {
-        document.removeEventListener('pointermove', onPointerMove);
-        document.removeEventListener('pointerup', onPointerUp);
-    });
-
     function onPointerDown(evt: PointerEvent): void {
         if (unref(disabled)) {
             return;
         }
 
         emit('dragging', true);
+        document.addEventListener('pointermove', onPointerMove);
+        document.addEventListener('pointerup', onPointerUp, {passive: true});
         requestAnimationFrame(() => onPointerMove(evt));
     }
 
@@ -77,12 +69,14 @@
         left += 6; // margin.
         width -= 12; // margin times two.
 
-        emit('update', Math.max(0, Math.min(1, (evt.pageX - left) / width)));
+        emit('update', Math.max(0, Math.min(1, (evt.clientX - left) / width)));
         evt.preventDefault();
     }
 
     function onPointerUp(): void {
         emit('dragging', false);
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointerup', onPointerUp);
     }
 
     watch(() => isDragging, () => emit('dragging', isDragging));

--- a/packages/components/src/component/primitive/SliderBase.vue
+++ b/packages/components/src/component/primitive/SliderBase.vue
@@ -22,7 +22,7 @@
     setup>
     import { unrefTemplateElement } from '@flux-ui/internals';
     import { clsx } from 'clsx';
-    import { toRef, unref, useTemplateRef, watch } from 'vue';
+    import { onUnmounted, toRef, unref, useTemplateRef } from 'vue';
     import { useDisabled } from '$flux/composable';
     import FluxTicks from '$flux/component/FluxTicks.vue';
     import $style from '$flux/css/component/primitive/Slider.module.scss';
@@ -79,5 +79,8 @@
         document.removeEventListener('pointerup', onPointerUp);
     }
 
-    watch(() => isDragging, () => emit('dragging', isDragging));
+    onUnmounted(() => {
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointerup', onPointerUp);
+    });
 </script>


### PR DESCRIPTION
## Summary

Critical code review findings addressed across `packages/components`:

**Bug fixes**
- `FluxFader`: `previous()` navigated forward instead of backward; guard against crash when `current` starts at `-1`
- `FluxFocalPointEditor`: used `pageX/Y` (document-relative) with `getBoundingClientRect()` (viewport-relative), causing incorrect focal point on scrolled pages
- `SliderBase`: same `pageX` → `clientX` issue
- `FluxFormTextArea`: `isReadonly` prop was declared but never bound to the `<textarea>` element
- `FilterItem`: watch only tracked `item`, not `value` — label was not refreshed when value changed
- `FluxColorPicker`: computed setter directly mutated the `hsv` ref array instead of working on a copy
- `FluxQuantitySelector`: `watchEffect` called `increment()` when value exceeded `max` (pushed it further up); replaced with direct clamp via `Math.min/max`
- `FluxSnackbar`: directly mutated `instance.props` object; replaced with spread copy
- `SelectBase`: key-press navigation only matched `[a-z]`, missing accented characters, digits and uppercase; now uses `evt.key.length === 1`
- `CoordinatePicker` / `SliderBase`: `pointermove`/`pointerup` listeners were registered on mount and active at all times; now only attached during active drag
- `FluxCalendar`: missing `:key` on `v-for` over `VNodeRenderer`

**Cleanup**
- `FluxBoxedIcon`: removed unused `click` emit definition
- `FluxColorSelect`: renamed `t` → `translate` for consistency with all other components
- `FluxFormDateRangeInput`: removed unused props (`autoComplete`, `autoFocus`, `isReadonly`, `placeholder`)
- `FluxFormSelect` / `FluxFormDateTimeInput`: removed unnecessary `unref()` calls on plain boolean props
- `FluxChip`: consistent `<Component>` / `</Component>` tag casing
- `FluxDatePicker`: removed contradictory `default: null` on a `required` model

## Test plan

- [x] Verify `FluxFader` navigates correctly with both `next()` and `previous()`
- [x] Verify `FluxFocalPointEditor` and `SliderBase` position correctly on a scrolled page
- [x] Verify `FluxFormTextArea` respects `isReadonly` prop
- [x] Verify `FluxFormSelect` type-ahead works with accented characters and digits
- [x] Verify `CoordinatePicker` and `SliderBase` do not fire unnecessary pointer events when idle
- [x] Verify `FluxQuantitySelector` clamps correctly when initial value is out of range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focal point coordinate calculation and slider pointer positioning.
  * Improved keyboard navigation to support single-character, case-insensitive input.
  * Corrected quantity selector clamping and fader backward cycling.
  * Stabilized calendar event rendering keys.

* **Improvements**
  * Added readonly support for textareas.
  * Better event listener lifecycle for draggable controls.
  * Improved immutability/reactivity in color and form components.
  * Cleaner snackbar object creation and localization naming.

* **Removals**
  * Removed unused props from date-range input.
  * Removed click event emission from boxed icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->