### PR TITLE
fix: improve accessibility and fix minor bugs across components

### DIFF
--- a/packages/components/src/component/FluxBadge.vue
+++ b/packages/components/src/component/FluxBadge.vue
@@ -40,7 +40,8 @@
             v-if="type === 'none' && isDeletable"
             :class="$style.badgeClose"
             type="button"
-            @click="onDeleteClick()">
+            :aria-label="translate('flux.delete')"
+            @click.stop="onDeleteClick()">
             <FluxIcon name="xmark"/>
         </button>
     </FluxPressable>
@@ -51,6 +52,7 @@
     setup>
     import type { FluxButtonEmits, FluxColor, FluxIconName, FluxPressableType, FluxTo } from '@flux-ui/types';
     import { clsx } from 'clsx';
+    import { useTranslate } from '$flux/composable/private';
     import FluxIcon from './FluxIcon.vue';
     import FluxPressable from './FluxPressable.vue';
     import FluxSpinner from './FluxSpinner.vue';
@@ -77,6 +79,8 @@
         readonly target?: string;
         readonly to?: FluxTo;
     }>();
+
+    const translate = useTranslate();
 
     function onDeleteClick(): void {
         emit('delete');

--- a/packages/components/src/component/FluxDivider.vue
+++ b/packages/components/src/component/FluxDivider.vue
@@ -6,7 +6,7 @@
             contentPlacement === 'end' && $style.dividerContentEnd
         )"
         role="separator"
-        aria-orientation="horizontal">
+        :aria-orientation="direction">
         <div
             v-if="slots.default"
             :class="$style.dividerContent">
@@ -22,13 +22,16 @@
 <script
     lang="ts"
     setup>
+    import type { FluxDirection } from '@flux-ui/types';
     import { clsx } from 'clsx';
     import $style from '$flux/css/component/Divider.module.scss';
 
     const {
-        contentPlacement = 'center'
+        contentPlacement = 'center',
+        direction = 'horizontal'
     } = defineProps<{
         readonly contentPlacement?: 'start' | 'center' | 'end';
+        readonly direction?: FluxDirection;
     }>();
 
     const slots = defineSlots<{

--- a/packages/components/src/component/FluxFormInputGroup.vue
+++ b/packages/components/src/component/FluxFormInputGroup.vue
@@ -5,7 +5,7 @@
             isCondensed && $style.isCondensed,
             isSecondary && $style.isSecondary
         )"
-        role="textbox">
+        role="group">
         <slot/>
     </div>
 </template>

--- a/packages/components/src/component/FluxFormSection.vue
+++ b/packages/components/src/component/FluxFormSection.vue
@@ -1,8 +1,8 @@
 <template>
     <div :class="$style.formSection">
-        <div :class="$style.formSectionTitle">
+        <h3 :class="$style.formSectionTitle">
             {{ title }}
-        </div>
+        </h3>
 
         <slot/>
     </div>

--- a/packages/components/src/component/FluxLegend.vue
+++ b/packages/components/src/component/FluxLegend.vue
@@ -1,14 +1,14 @@
 <template>
     <div :class="direction === 'horizontal' ? $style.legendHorizontal : $style.legendVertical">
-        <template v-for="item of items">
-            <span
-                :class="$style.legendItem"
-                :style="{
-                    '--color': item.color
-                }">
-                {{ item.label }}
-            </span>
-        </template>
+        <span
+            v-for="(item, index) of items"
+            :key="index"
+            :class="$style.legendItem"
+            :style="{
+                '--color': item.color
+            }">
+            {{ item.label }}
+        </span>
     </div>
 </template>
 

--- a/packages/components/src/component/FluxNotice.vue
+++ b/packages/components/src/component/FluxNotice.vue
@@ -40,6 +40,7 @@
             v-if="isCloseable"
             :class="$style.noticeClose"
             type="button"
+            :aria-label="translate('flux.close')"
             @click="emit('close')">
             <FluxIcon name="xmark"/>
         </button>
@@ -51,6 +52,7 @@
     setup>
     import type { FluxColor, FluxIconName } from '@flux-ui/types';
     import { clsx } from 'clsx';
+    import { useTranslate } from '$flux/composable/private';
     import FluxIcon from './FluxIcon.vue';
     import FluxSpinner from './FluxSpinner.vue';
     import $style from '$flux/css/component/Notice.module.scss';
@@ -76,4 +78,6 @@
         default(): any;
         end(): any;
     }>();
+
+    const translate = useTranslate();
 </script>

--- a/packages/components/src/component/FluxPercentageBar.vue
+++ b/packages/components/src/component/FluxPercentageBar.vue
@@ -1,7 +1,9 @@
 <template>
     <div :class="$style.percentageBar">
         <div :class="$style.percentageBarTrack">
-            <FluxTooltip v-for="item of items">
+            <FluxTooltip
+                v-for="(item, index) of items"
+                :key="index">
                 <template #content>
                     <div :class="$style.percentageBarTooltip">
                         <FluxIcon

--- a/packages/components/src/component/FluxRemove.vue
+++ b/packages/components/src/component/FluxRemove.vue
@@ -5,6 +5,7 @@
             isHidden && $style.isHidden
         )"
         type="button"
+        :aria-label="translate('flux.delete')"
         @click="emit('click', $event)">
         <FluxIcon
             v-if="icon"
@@ -18,6 +19,7 @@
     setup>
     import type { FluxIconName } from '@flux-ui/types';
     import { clsx } from 'clsx';
+    import { useTranslate } from '$flux/composable/private';
     import FluxIcon from './FluxIcon.vue';
     import $style from '$flux/css/component/Remove.module.scss';
 
@@ -31,4 +33,6 @@
         readonly icon?: FluxIconName;
         readonly isHidden?: boolean;
     }>();
+
+    const translate = useTranslate();
 </script>

--- a/packages/components/src/component/FluxStack.vue
+++ b/packages/components/src/component/FluxStack.vue
@@ -9,7 +9,7 @@
             isWrapping && $style.isWrapping
         )"
         :style="{
-            '--gap': gap && `${gap}px`
+            '--gap': gap != null ? `${gap}px` : undefined
         }">
         <slot/>
     </Component>

--- a/packages/components/src/component/FluxTableCell.vue
+++ b/packages/components/src/component/FluxTableCell.vue
@@ -13,7 +13,7 @@
                 :class="$style.tableCellContent"
                 :style="{
                     flexFlow: contentDirection,
-                    gap: contentGap && `${contentGap}px`
+                    gap: contentGap != null ? `${contentGap}px` : undefined
                 }">
                 <slot/>
             </div>

--- a/packages/components/src/component/FluxTableHeader.vue
+++ b/packages/components/src/component/FluxTableHeader.vue
@@ -6,6 +6,7 @@
             isShrinking && $style.isShrinking,
             isSticky && $style.isSticky
         )"
+        scope="col"
         :style="{
             minWidth: `${minWidth}px`
         }">

--- a/packages/components/src/component/FluxTabs.vue
+++ b/packages/components/src/component/FluxTabs.vue
@@ -8,6 +8,8 @@
                     v-for="(tab, index) of tabs"
                     :key="index">
                     <FluxTabBarItem
+                        :id="`${baseId}-tab-${index}`"
+                        :aria-controls="`${baseId}-panel-${index}`"
                         :icon="tab.icon"
                         :is-active="modelValue === index"
                         :label="tab.label"
@@ -33,7 +35,7 @@
     setup>
     import { flattenVNodeTree, getComponentProps } from '@flux-ui/internals';
     import type { FluxIconName } from '@flux-ui/types';
-    import { computed, ref, unref, type VNode, watch } from 'vue';
+    import { cloneVNode, computed, ref, unref, useId, type VNode, watch } from 'vue';
     import { FluxWindowTransition } from '$flux/transition';
     import { VNodeRenderer } from './primitive';
     import FluxTabBar from './FluxTabBar.vue';
@@ -70,10 +72,17 @@
         }): any;
     }>();
 
+    const baseId = useId();
     const isTransitioningBack = ref(false);
 
-    const children = computed(() => flattenVNodeTree(slots.default?.() ?? []));
-    const tabs = computed<{ icon?: FluxIconName; label?: string; }[]>(() => unref(children)
+    const rawChildren = computed(() => flattenVNodeTree(slots.default?.() ?? []));
+
+    const children = computed(() => unref(rawChildren).map((child, index) => cloneVNode(child, {
+        id: `${baseId}-panel-${index}`,
+        'aria-labelledby': `${baseId}-tab-${index}`
+    })));
+
+    const tabs = computed<{ icon?: FluxIconName; label?: string; }[]>(() => unref(rawChildren)
         .filter((child: VNode) => getComponentProps<any>(child).icon || getComponentProps<any>(child).label)
         .map((child: VNode) => ({
             icon: getComponentProps<any>(child).icon,

--- a/packages/components/src/component/FluxTag.vue
+++ b/packages/components/src/component/FluxTag.vue
@@ -41,7 +41,8 @@
             v-if="!isClickable && isDeletable"
             :class="$style.tagClose"
             type="button"
-            @click="onDeleteClick()">
+            :aria-label="translate('flux.delete')"
+            @click.stop="onDeleteClick()">
             <FluxIcon name="xmark"/>
         </button>
     </FluxPressable>
@@ -52,6 +53,7 @@
     setup>
     import type { FluxButtonEmits, FluxColor, FluxIconName, FluxPressableType, FluxTo } from '@flux-ui/types';
     import { clsx } from 'clsx';
+    import { useTranslate } from '$flux/composable/private';
     import FluxIcon from './FluxIcon.vue';
     import FluxPressable from './FluxPressable.vue';
     import FluxSpinner from './FluxSpinner.vue';
@@ -80,6 +82,8 @@
         readonly target?: string;
         readonly to?: FluxTo;
     }>();
+
+    const translate = useTranslate();
 
     function onDeleteClick(): void {
         emit('delete');

--- a/packages/components/src/component/FluxTreeView.vue
+++ b/packages/components/src/component/FluxTreeView.vue
@@ -16,6 +16,7 @@
             role="treeitem"
             tabindex="-1"
             :aria-expanded="node.children?.length ? expandedIds.has(node.id) : undefined"
+            :aria-level="node.depth + 1"
             @click="onNodeClick(node)"
             @dblclick="onNodeDblClick(node)">
 

--- a/packages/components/src/data/i18n.ts
+++ b/packages/components/src/data/i18n.ts
@@ -4,9 +4,11 @@ export type FluxTranslation = keyof typeof english;
 export const english = {
     'flux.back': 'Back',
     'flux.cancel': 'Cancel',
+    'flux.close': 'Close',
     'flux.comingSoon': 'Coming soon',
     'flux.continue': 'Continue',
     'flux.customPeriod': 'Custom period',
+    'flux.delete': 'Delete',
     'flux.filter': 'Filter',
     'flux.filterReset': 'Reset filters',
     'flux.justNow': 'Just now',


### PR DESCRIPTION
- Fix gap=0 not being applied in FluxStack and FluxTableCell
- Add missing v-for keys in FluxPercentageBar and FluxLegend
- Add aria-labels to icon-only buttons (FluxRemove, FluxBadge, FluxTag, FluxNotice)
- Add scope="col" to FluxTableHeader for screen reader support
- Add aria-level to FluxTreeView tree items
- Link tab panels with aria-labelledby/aria-controls in FluxTabs
- Fix event propagation on delete buttons in FluxBadge and FluxTag
- Change role="textbox" to role="group" in FluxFormInputGroup
- Use semantic h3 for section title in FluxFormSection
- Add direction prop to FluxDivider for dynamic aria-orientation
- Add flux.close and flux.delete i18n keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Enhancements**
  * Added accessible labels to delete and close buttons across components.
  * Enhanced screen reader support with improved ARIA attributes (tab-panel relationships, tree hierarchy levels, semantic roles).
  * Updated header semantics and table column scopes.

* **Bug Fixes**
  * Fixed spacing calculations to properly handle zero-value gaps.
  * Resolved event propagation in delete button interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->