### PR TITLE
feat(typography): add FluxTypography prose component

### DIFF
--- a/docs/.vitepress/component-navigation.ts
+++ b/docs/.vitepress/component-navigation.ts
@@ -12,7 +12,8 @@ const navigation: SidebarItem[] = [
             {text: 'Link', link: '/components/link', image: '/assets/components/link.svg'},
             {text: 'Pressable', link: '/components/pressable'},
             {text: 'Root', link: '/components/root'},
-            {text: 'Text', link: '/components/text'}
+            {text: 'Text', link: '/components/text'},
+            {text: 'Typography', link: '/components/typography'}
         ]
     },
     {

--- a/docs/.vitepress/theme/FluxView.vue
+++ b/docs/.vitepress/theme/FluxView.vue
@@ -14,7 +14,7 @@
             line-height: 1.6;
         }
 
-        :global(p) {
+        :global(p:not(:where([data-flux-typography] *))) {
             margin: unset;
             line-height: 1.6;
         }

--- a/docs/.vitepress/theme/override/vp-doc.css
+++ b/docs/.vitepress/theme/override/vp-doc.css
@@ -13,13 +13,13 @@
     outline: none;
 }
 
-.vp-doc h1 {
+.vp-doc h1:not(:where([data-flux-typography] *)) {
     letter-spacing: -0.02em;
     line-height: 40px;
     font-size: 28px;
 }
 
-.vp-doc h2 {
+.vp-doc h2:not(:where([data-flux-typography] *)) {
     margin: 48px 0 16px;
     border-top: 1px solid var(--vp-c-divider);
     padding-top: 24px;
@@ -28,14 +28,14 @@
     font-size: 24px;
 }
 
-.vp-doc h3 {
+.vp-doc h3:not(:where([data-flux-typography] *)) {
     margin: 32px 0 0;
     letter-spacing: -0.01em;
     line-height: 28px;
     font-size: 20px;
 }
 
-.vp-doc h4 {
+.vp-doc h4:not(:where([data-flux-typography] *)) {
     margin: 24px 0 0;
     letter-spacing: -0.01em;
     line-height: 24px;
@@ -76,7 +76,7 @@
 }
 
 @media (min-width: 768px) {
-    .vp-doc h1 {
+    .vp-doc h1:not(:where([data-flux-typography] *)) {
         letter-spacing: -0.02em;
         line-height: 40px;
         font-size: 32px;
@@ -91,16 +91,16 @@
  * Paragraph and inline elements
  * -------------------------------------------------------------------------- */
 
-.vp-doc p,
-.vp-doc summary {
+.vp-doc p:not(:where([data-flux-typography] *)),
+.vp-doc summary:not(:where([data-flux-typography] *)) {
     margin: 16px 0;
 }
 
-.vp-doc p {
+.vp-doc p:not(:where([data-flux-typography] *)) {
     line-height: 28px;
 }
 
-.vp-doc blockquote {
+.vp-doc blockquote:not(:where([data-flux-typography] *)) {
     margin: 16px 0;
     border-left: 2px solid var(--vp-c-divider);
     padding-left: 16px;
@@ -108,7 +108,7 @@
     color: var(--vp-c-text-2);
 }
 
-.vp-doc blockquote > p {
+.vp-doc blockquote:not(:where([data-flux-typography] *)) > p {
     margin: 0;
     font-size: 16px;
     transition: color 0.5s;
@@ -136,26 +136,26 @@
  * Lists
  * -------------------------------------------------------------------------- */
 
-.vp-doc ul,
-.vp-doc ol {
+.vp-doc ul:not(:where([data-flux-typography] *)),
+.vp-doc ol:not(:where([data-flux-typography] *)) {
     padding-left: 1.25rem;
     margin: 16px 0;
 }
 
-.vp-doc ul {
+.vp-doc ul:not(:where([data-flux-typography] *)) {
     list-style: disc;
 }
 
-.vp-doc ol {
+.vp-doc ol:not(:where([data-flux-typography] *)) {
     list-style: decimal;
 }
 
-.vp-doc li + li {
+.vp-doc li:not(:where([data-flux-typography] *)) + li {
     margin-top: 8px;
 }
 
-.vp-doc li > ol,
-.vp-doc li > ul {
+.vp-doc li:not(:where([data-flux-typography] *)) > ol,
+.vp-doc li:not(:where([data-flux-typography] *)) > ul {
     margin: 8px 0 0;
 }
 
@@ -163,7 +163,7 @@
  * Decorational elements
  * -------------------------------------------------------------------------- */
 
-.vp-doc hr:not(:only-child) {
+.vp-doc hr:not(:only-child):not(:where([data-flux-typography] *)) {
     margin: 16px 0;
     border: none;
     border-top: 1px solid var(--vp-c-divider);
@@ -206,12 +206,12 @@
  * -------------------------------------------------------------------------- */
 
 /* inline code */
-.vp-doc :not(pre, h1, h2, h3, h4, h5, h6) > code {
+.vp-doc :not(pre, h1, h2, h3, h4, h5, h6):not(:where([data-flux-typography] *)) > code {
     font-size: var(--vp-code-font-size);
     color: var(--vp-code-color);
 }
 
-.vp-doc :not(pre) > code {
+.vp-doc :not(pre):not(:where([data-flux-typography] *)) > code {
     border-radius: 4px;
     padding: 3px 6px;
     background-color: var(--vp-code-bg);
@@ -283,7 +283,7 @@
     hyphens: none;
 }
 
-.vp-doc [class*='language-'] pre {
+.vp-doc [class*='language-'] pre:not(:where([data-flux-typography] *)) {
     position: relative;
     z-index: 1;
     margin: 0;
@@ -292,7 +292,7 @@
     overflow-x: auto;
 }
 
-.vp-doc [class*='language-'] code {
+.vp-doc [class*='language-'] code:not(:where([data-flux-typography] *)) {
     display: block;
     padding: 0 24px;
     width: fit-content;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -37,7 +37,7 @@ button {
     padding: 18px;
 }
 
-.vp-adaptive-theme p {
+.vp-adaptive-theme p:not(:where([data-flux-typography] *)) {
     margin: unset;
 }
 
@@ -101,12 +101,12 @@ button {
     z-index: 0;
 }
 
-.vp-code-group .blocks :where(h1, h2, h3, h4, h5, h6) {
+.vp-code-group .blocks :where(h1, h2, h3, h4, h5, h6):not(:where([data-flux-typography] *)) {
     margin: unset;
     line-height: 1.6;
 }
 
-.vp-code-group .blocks p {
+.vp-code-group .blocks p:not(:where([data-flux-typography] *)) {
     margin: unset;
     line-height: 1.6;
 }

--- a/docs/code/components/flyout/preview.vue
+++ b/docs/code/components/flyout/preview.vue
@@ -11,12 +11,14 @@
             <template #default="{ close }">
                 <FluxPane style="max-width: 420px">
                     <FluxPaneBody>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. A asperiores cum debitis dolor, explicabo facere illo ipsa iste labore, maiores molestias odit optio qui quo reprehenderit ut veniam veritatis. Saepe.</p>
+                        <FluxTypography>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. A asperiores cum debitis dolor, explicabo facere illo ipsa iste labore, maiores molestias odit optio qui quo reprehenderit ut veniam veritatis. Saepe.</p>
 
-                        <FluxSecondaryButton
-                            data-typography-aware
-                            label="Close"
-                            @click="close()"/>
+                            <FluxSecondaryButton
+                                data-typography-aware
+                                label="Close"
+                                @click="close()"/>
+                        </FluxTypography>
                     </FluxPaneBody>
                 </FluxPane>
             </template>
@@ -27,5 +29,5 @@
 <script
     lang="ts"
     setup>
-    import { FluxFlyout, FluxPane, FluxPaneBody, FluxSecondaryButton } from '@flux-ui/components';
+    import { FluxFlyout, FluxPane, FluxPaneBody, FluxSecondaryButton, FluxTypography } from '@flux-ui/components';
 </script>

--- a/docs/code/components/typography/article.vue
+++ b/docs/code/components/typography/article.vue
@@ -1,0 +1,91 @@
+<template>
+    <FluxTypography tag="article">
+        <h1>Designing with type</h1>
+        <p>Typography is the craft of arranging text so it is <a href="#">legible, readable and appealing</a> when displayed. Good type sets a rhythm the reader can follow without conscious effort, and it is the single biggest lever you have over how <strong>trustworthy</strong> an interface feels.</p>
+
+        <h2>The vertical rhythm</h2>
+        <p>Every block of content, whether a paragraph, a list, an image or a table, sits on a consistent baseline. Spacing scales with the weight of the element: a new section gets more room above it than the next paragraph does.</p>
+
+        <blockquote>Typography is the detail and the presentation of a story. It represents the voice of an atmosphere, or a historical setting of some kind.</blockquote>
+
+        <h3>Working with lists</h3>
+        <p>Lists break dense information into scannable chunks. Reach for an unordered list when order does not matter:</p>
+        <ul>
+            <li>Keep the measure between 45 and 75 characters.
+                <ul>
+                    <li>Narrower for captions.</li>
+                    <li>Wider for long form reading.</li>
+                </ul>
+            </li>
+            <li>Set a generous line height for body copy.</li>
+            <li>Limit the number of distinct type sizes.</li>
+        </ul>
+
+        <p>Use an ordered list when the sequence itself is the point:</p>
+        <ol>
+            <li>Establish a base font size.</li>
+            <li>Derive a modular scale from it.</li>
+            <li>Assign each level a single, clear role.</li>
+        </ol>
+
+        <h3>Code and keys</h3>
+        <p>Wrap identifiers such as <code>--font-sans</code> in inline code, and show a full snippet in a block:</p>
+        <pre><code>:root {
+    --font-sans: inter-variable, sans-serif;
+}</code></pre>
+        <p>Document shortcuts with the keyboard element: press <kbd>Cmd</kbd> + <kbd>B</kbd> to toggle bold.</p>
+
+        <FluxTypographyReset>
+            <FluxPane>
+                <FluxPaneHeader
+                    icon="circle-info"
+                    subtitle="Rendered inside FluxTypographyReset"
+                    title="Embedded component"/>
+                <FluxPaneBody>
+                    This pane keeps its own styling. Typography Reset stops the prose rules from reaching in, yet the block still flows in the article rhythm just like a paragraph or a heading.
+                </FluxPaneBody>
+            </FluxPane>
+        </FluxTypographyReset>
+
+        <h2>A quick reference</h2>
+        <p>The scale below summarises the default roles.</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>Element</th>
+                    <th>Size</th>
+                    <th>Role</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Heading 1</td>
+                    <td>27px</td>
+                    <td>Page title</td>
+                </tr>
+                <tr>
+                    <td>Heading 2</td>
+                    <td>21px</td>
+                    <td>Section heading</td>
+                </tr>
+                <tr>
+                    <td>Body</td>
+                    <td>15px</td>
+                    <td>Paragraphs and lists</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <hr/>
+
+        <p>Finally, imagery breaks up long stretches of text and gives the eye a place to rest.</p>
+        <img src="https://images.pexels.com/photos/33688/delicate-arch-night-stars-landscape.jpg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
+            alt=""/>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxPane, FluxPaneBody, FluxPaneHeader, FluxTypography, FluxTypographyReset } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/blockquote.vue
+++ b/docs/code/components/typography/blockquote.vue
@@ -1,0 +1,12 @@
+<template>
+    <FluxTypography>
+        <p>As Robert Bringhurst reminds us in his classic manual:</p>
+        <blockquote>Typography exists to honor content. Its purpose is to serve the reader, not to draw attention to itself.</blockquote>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/code.vue
+++ b/docs/code/components/typography/code.vue
@@ -1,0 +1,15 @@
+<template>
+    <FluxTypography>
+        <p>Install the package with your favourite manager, then import <code>FluxTypography</code> where you need it.</p>
+        <pre><code>import { FluxTypography } from '@flux-ui/components';
+
+const article = FluxTypography;</code></pre>
+        <p>Press <kbd>Cmd</kbd> + <kbd>K</kbd> to open the command palette.</p>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/headings.vue
+++ b/docs/code/components/typography/headings.vue
@@ -1,0 +1,16 @@
+<template>
+    <FluxTypography>
+        <h1>Heading 1</h1>
+        <h2>Heading 2</h2>
+        <h3>Heading 3</h3>
+        <h4>Heading 4</h4>
+        <h5>Heading 5</h5>
+        <h6>Heading 6</h6>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/lists.vue
+++ b/docs/code/components/typography/lists.vue
@@ -1,0 +1,28 @@
+<template>
+    <FluxTypography>
+        <h3>Unordered list</h3>
+        <ul>
+            <li>Espresso, the concentrated base for most drinks.
+                <ul>
+                    <li>Ristretto</li>
+                    <li>Lungo</li>
+                </ul>
+            </li>
+            <li>Filter, brewed slowly for a lighter body.</li>
+            <li>Cold brew, steeped for many hours.</li>
+        </ul>
+
+        <h3>Ordered list</h3>
+        <ol>
+            <li>Grind the beans just before brewing.</li>
+            <li>Rinse the filter and preheat the cup.</li>
+            <li>Pour in slow, steady circles.</li>
+        </ol>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/paragraph.vue
+++ b/docs/code/components/typography/paragraph.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script
-    setup
-    lang="ts">
+    lang="ts"
+    setup>
     import { FluxTypography } from '@flux-ui/components';
 </script>

--- a/docs/code/components/typography/preview.vue
+++ b/docs/code/components/typography/preview.vue
@@ -1,0 +1,24 @@
+<template>
+    <Preview>
+        <FluxTypography tag="article">
+            <h2>The art of typesetting</h2>
+            <p>Good typography is invisible. It guides the reader from one idea to the next without ever calling attention to itself, balancing rhythm, contrast and whitespace.</p>
+
+            <h3>Why it matters</h3>
+            <p>Consistent spacing and a clear hierarchy make long form content effortless to scan. A well set page respects the reader's time.</p>
+
+            <ul>
+                <li>A measured line length keeps the eye from getting lost.</li>
+                <li>Generous leading gives each line room to breathe.</li>
+            </ul>
+
+            <blockquote>Typography is what language looks like.</blockquote>
+        </FluxTypography>
+    </Preview>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/reset.vue
+++ b/docs/code/components/typography/reset.vue
@@ -1,0 +1,41 @@
+<template>
+    <FluxTypography>
+        <h3>Styled table</h3>
+        <p>A bare table inside Typography gets prose borders and padding.</p>
+        <table>
+            <tbody>
+                <tr>
+                    <td>Light</td>
+                    <td>Delicate</td>
+                </tr>
+                <tr>
+                    <td>Dark</td>
+                    <td>Full</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h3>Reset table</h3>
+        <p>Wrapped in Typography Reset, the same markup keeps its own styling but still flows in the rhythm.</p>
+        <FluxTypographyReset>
+            <table>
+                <tbody>
+                    <tr>
+                        <td>Light</td>
+                        <td>Delicate</td>
+                    </tr>
+                    <tr>
+                        <td>Dark</td>
+                        <td>Full</td>
+                    </tr>
+                </tbody>
+            </table>
+        </FluxTypographyReset>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography, FluxTypographyReset } from '@flux-ui/components';
+</script>

--- a/docs/code/components/typography/table.vue
+++ b/docs/code/components/typography/table.vue
@@ -1,0 +1,36 @@
+<template>
+    <FluxTypography>
+        <table>
+            <thead>
+                <tr>
+                    <th>Roast</th>
+                    <th>Body</th>
+                    <th>Acidity</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Light</td>
+                    <td>Delicate</td>
+                    <td>High</td>
+                </tr>
+                <tr>
+                    <td>Medium</td>
+                    <td>Balanced</td>
+                    <td>Medium</td>
+                </tr>
+                <tr>
+                    <td>Dark</td>
+                    <td>Full</td>
+                    <td>Low</td>
+                </tr>
+            </tbody>
+        </table>
+    </FluxTypography>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxTypography } from '@flux-ui/components';
+</script>

--- a/docs/code/guide/introduction/typography/blockquote.vue
+++ b/docs/code/guide/introduction/typography/blockquote.vue
@@ -1,8 +1,11 @@
 <template>
-    <blockquote>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias atque dolor doloribus eos exercitationem fugit harum id in labore laborum maiores nemo nulla omnis provident, quia quidem quod sit voluptas.</blockquote>
+    <FluxTypography>
+        <blockquote>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias atque dolor doloribus eos exercitationem fugit harum id in labore laborum maiores nemo nulla omnis provident, quia quidem quod sit voluptas.</blockquote>
+    </FluxTypography>
 </template>
 
 <script
     setup
     lang="ts">
+    import { FluxTypography } from '@flux-ui/components';
 </script>

--- a/docs/code/guide/introduction/typography/headings.vue
+++ b/docs/code/guide/introduction/typography/headings.vue
@@ -1,13 +1,16 @@
 <template>
-    <h1>Flux heading 1</h1>
-    <h2>Flux heading 2</h2>
-    <h3>Flux heading 3</h3>
-    <h4>Flux heading 4</h4>
-    <h5>Flux heading 5</h5>
-    <h6>Flux heading 6</h6>
+    <FluxTypography>
+        <h1>Flux heading 1</h1>
+        <h2>Flux heading 2</h2>
+        <h3>Flux heading 3</h3>
+        <h4>Flux heading 4</h4>
+        <h5>Flux heading 5</h5>
+        <h6>Flux heading 6</h6>
+    </FluxTypography>
 </template>
 
 <script
     setup
     lang="ts">
+    import { FluxTypography } from '@flux-ui/components';
 </script>

--- a/docs/code/guide/introduction/typography/image.vue
+++ b/docs/code/guide/introduction/typography/image.vue
@@ -1,9 +1,12 @@
 <template>
-    <img src="https://images.pexels.com/photos/33688/delicate-arch-night-stars-landscape.jpg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
-        alt=""/>
+    <FluxTypography>
+        <img src="https://images.pexels.com/photos/33688/delicate-arch-night-stars-landscape.jpg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
+            alt=""/>
+    </FluxTypography>
 </template>
 
 <script
     setup
     lang="ts">
+    import { FluxTypography } from '@flux-ui/components';
 </script>

--- a/docs/code/guide/introduction/typography/lists.vue
+++ b/docs/code/guide/introduction/typography/lists.vue
@@ -1,20 +1,23 @@
 <template>
-    <h3>Unordered list</h3>
-    <ul>
-        <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid cumque exercitationem fugiat fugit id impedit laborum rerum sunt, vel. Animi consequuntur delectus eius excepturi modi praesentium quaerat quisquam unde! Voluptatum.</li>
-        <li>Accusantium ducimus eligendi esse placeat repellendus. Ad aperiam asperiores autem consectetur deleniti dolore, doloribus, dolorum ducimus explicabo, in ipsa iure labore natus necessitatibus nesciunt nihil officiis reprehenderit veritatis vitae voluptates!</li>
-        <li>Assumenda at culpa debitis delectus deleniti, deserunt explicabo inventore nostrum nulla rem sint tempore velit. Accusamus aliquid amet aperiam, delectus esse et fugit molestias, nihil omnis pariatur perferendis, placeat rem.</li>
-    </ul>
+    <FluxTypography>
+        <h3>Unordered list</h3>
+        <ul>
+            <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid cumque exercitationem fugiat fugit id impedit laborum rerum sunt, vel. Animi consequuntur delectus eius excepturi modi praesentium quaerat quisquam unde! Voluptatum.</li>
+            <li>Accusantium ducimus eligendi esse placeat repellendus. Ad aperiam asperiores autem consectetur deleniti dolore, doloribus, dolorum ducimus explicabo, in ipsa iure labore natus necessitatibus nesciunt nihil officiis reprehenderit veritatis vitae voluptates!</li>
+            <li>Assumenda at culpa debitis delectus deleniti, deserunt explicabo inventore nostrum nulla rem sint tempore velit. Accusamus aliquid amet aperiam, delectus esse et fugit molestias, nihil omnis pariatur perferendis, placeat rem.</li>
+        </ul>
 
-    <h3>Ordered list</h3>
-    <ol>
-        <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid cumque exercitationem fugiat fugit id impedit laborum rerum sunt, vel. Animi consequuntur delectus eius excepturi modi praesentium quaerat quisquam unde! Voluptatum.</li>
-        <li>Accusantium ducimus eligendi esse placeat repellendus. Ad aperiam asperiores autem consectetur deleniti dolore, doloribus, dolorum ducimus explicabo, in ipsa iure labore natus necessitatibus nesciunt nihil officiis reprehenderit veritatis vitae voluptates!</li>
-        <li>Assumenda at culpa debitis delectus deleniti, deserunt explicabo inventore nostrum nulla rem sint tempore velit. Accusamus aliquid amet aperiam, delectus esse et fugit molestias, nihil omnis pariatur perferendis, placeat rem.</li>
-    </ol>
+        <h3>Ordered list</h3>
+        <ol>
+            <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid cumque exercitationem fugiat fugit id impedit laborum rerum sunt, vel. Animi consequuntur delectus eius excepturi modi praesentium quaerat quisquam unde! Voluptatum.</li>
+            <li>Accusantium ducimus eligendi esse placeat repellendus. Ad aperiam asperiores autem consectetur deleniti dolore, doloribus, dolorum ducimus explicabo, in ipsa iure labore natus necessitatibus nesciunt nihil officiis reprehenderit veritatis vitae voluptates!</li>
+            <li>Assumenda at culpa debitis delectus deleniti, deserunt explicabo inventore nostrum nulla rem sint tempore velit. Accusamus aliquid amet aperiam, delectus esse et fugit molestias, nihil omnis pariatur perferendis, placeat rem.</li>
+        </ol>
+    </FluxTypography>
 </template>
 
 <script
     setup
     lang="ts">
+    import { FluxTypography } from '@flux-ui/components';
 </script>

--- a/docs/components/typography.md
+++ b/docs/components/typography.md
@@ -36,7 +36,7 @@ Outside of Typography, Flux keeps only light element defaults (heading sizes, li
 
 By default Typography renders a `div`. Set `tag` to render a different wrapper such as an `article`, or use `as-child` to merge the styling onto the single child element without any wrapper at all.
 
-For long form reading, add the `container` prop to cap the content at a comfortable measure and center it. The width is driven by the `--flux-typography-container` custom property (default `90ch`), so you can set it to `72ch`, `78ch`, `84ch` or any value you like.
+For long-form reading, add the `container` prop to cap the content at a comfortable measure and center it. The width is driven by the `--flux-typography-container` custom property (default `90ch`), so you can set it to `72ch`, `78ch`, `84ch` or any value you like.
 
 Use [Text](/components/text) instead when you need a single styled piece of inline text, such as a label, a metric or a caption. Typography is for flowing document content, Text is for individual strings.
 

--- a/docs/components/typography.md
+++ b/docs/components/typography.md
@@ -1,0 +1,77 @@
+---
+outline: deep
+
+props:
+    -   name: asChild
+        description: Merges the typography styling onto the single child element instead of rendering a wrapper. Useful when you already have a semantic root such as an article.
+        type: boolean
+        optional: true
+
+    -   name: container
+        description: Constrains the content to a centered reading measure. Set the width through the --flux-typography-container custom property, which defaults to 90ch.
+        type: boolean
+        optional: true
+
+    -   name: tag
+        description: The HTML element that is rendered. Defaults to a div, use article or section for document content.
+        type: string
+        optional: true
+
+slots:
+    -   name: default
+        description: The prose content, made up of regular HTML elements such as headings, paragraphs, lists and tables.
+---
+
+# Typography
+
+The Typography component turns plain HTML into rich, readable prose. Everything you drop inside it, headings, paragraphs, lists, blockquotes, code, tables and images, is styled with a consistent type scale and vertical rhythm, so you can write an article without reaching for custom CSS.
+
+::: render
+render=../code/components/typography/preview.vue
+:::
+
+::: tip
+Outside of Typography, Flux keeps only light element defaults (heading sizes, link and monospace styling). The rich prose styling, vertical rhythm, decorated blockquotes, list markers and table borders, applies only within `FluxTypography`.
+:::
+
+By default Typography renders a `div`. Set `tag` to render a different wrapper such as an `article`, or use `as-child` to merge the styling onto the single child element without any wrapper at all.
+
+For long form reading, add the `container` prop to cap the content at a comfortable measure and center it. The width is driven by the `--flux-typography-container` custom property (default `90ch`), so you can set it to `72ch`, `78ch`, `84ch` or any value you like.
+
+Use [Text](/components/text) instead when you need a single styled piece of inline text, such as a label, a metric or a caption. Typography is for flowing document content, Text is for individual strings.
+
+<FrontmatterDocs/>
+
+## Examples
+
+::: example Headings || The six heading levels, each with its own size and weight.
+example=../code/components/typography/headings.vue
+:::
+
+::: example Paragraphs || Body copy flows with a comfortable line height and automatic spacing between blocks.
+example=../code/components/typography/paragraph.vue
+:::
+
+::: example Lists || Ordered and unordered lists get markers, indentation and nested styling.
+example=../code/components/typography/lists.vue
+:::
+
+::: example Blockquote || A quote is set off with an accent border and italics.
+example=../code/components/typography/blockquote.vue
+:::
+
+::: example Code || Inline code renders as a chip, while a pre block becomes a scrollable code block.
+example=../code/components/typography/code.vue
+:::
+
+::: example Table || Tables get borders, padding and a subtle header background.
+example=../code/components/typography/table.vue
+:::
+
+::: example Reset || Wrap a foreign component in Typography Reset to keep it out of the prose styling while it still flows in the vertical rhythm.
+example=../code/components/typography/reset.vue
+:::
+
+::: example Full article || Everything together: headings, body copy, lists, a blockquote, inline and block code, a keyboard shortcut, a table, an image, and a Flux pane embedded through Typography Reset.
+example=../code/components/typography/article.vue
+:::

--- a/docs/guide/introduction/typography.md
+++ b/docs/guide/introduction/typography.md
@@ -6,6 +6,8 @@ outline: deep
 
 Flux ships a consistent typographic system covering font families, sizes, weights, and spacing. This page documents how typography works in Flux and how to apply it to text throughout your application.
 
+Outside of any container, Flux applies only light element defaults: heading sizes and weights, link styling and a monospace font for code. Rich prose, with vertical rhythm, decorated blockquotes, list markers and styled tables, lives inside the [Typography](/components/typography) component. Every example below is wrapped in `FluxTypography`.
+
 ::: tip
 Flux uses the [Inter Variable](https://rsms.me/inter/) font family by default, you will need to include the font in your application for it to work.
 :::

--- a/packages/components/src/component/FluxTypography.vue
+++ b/packages/components/src/component/FluxTypography.vue
@@ -1,0 +1,42 @@
+<template>
+    <component :is="rendered"/>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { flattenVNodeTree } from '@flux-ui/internals';
+    import { clsx } from 'clsx';
+    import { cloneVNode, computed, h, useSlots, type VNode } from 'vue';
+    import $style from '~flux/components/css/component/Typography.module.scss';
+
+    const {
+        asChild,
+        container,
+        tag
+    } = defineProps<{
+        readonly asChild?: boolean;
+        readonly container?: boolean;
+        readonly tag?: keyof HTMLElementTagNameMap;
+    }>();
+
+    defineSlots<{
+        default(): VNode[];
+    }>();
+
+    const slots = useSlots();
+
+    const rendered = computed(() => {
+        const children = flattenVNodeTree(slots.default?.() ?? []);
+        const extra = {
+            class: clsx($style.typography, container && $style.container),
+            'data-flux-typography': ''
+        };
+
+        if (asChild && children.length === 1) {
+            return cloneVNode(children[0], extra);
+        }
+
+        return h(tag ?? 'div', extra, children);
+    });
+</script>

--- a/packages/components/src/component/FluxTypographyReset.vue
+++ b/packages/components/src/component/FluxTypographyReset.vue
@@ -1,0 +1,22 @@
+<template>
+    <Component
+        :is="tag ?? 'div'"
+        data-flux-prose-reset
+        data-typography-aware>
+        <slot/>
+    </Component>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import type { VNode } from 'vue';
+
+    defineProps<{
+        readonly tag?: keyof HTMLElementTagNameMap;
+    }>();
+
+    defineSlots<{
+        default(): VNode[];
+    }>();
+</script>

--- a/packages/components/src/component/index.ts
+++ b/packages/components/src/component/index.ts
@@ -183,4 +183,6 @@ export { default as FluxTooltipProvider } from './FluxTooltipProvider.vue';
 export { default as FluxTour } from './FluxTour.vue';
 export { default as FluxTourItem } from './FluxTourItem.vue';
 export { default as FluxTreeView } from './FluxTreeView.vue';
+export { default as FluxTypography } from './FluxTypography.vue';
+export { default as FluxTypographyReset } from './FluxTypographyReset.vue';
 export { default as FluxWindow } from './FluxWindow.vue';

--- a/packages/components/src/css/component/Typography.module.scss
+++ b/packages/components/src/css/component/Typography.module.scss
@@ -1,0 +1,150 @@
+// Prose styling is skipped inside a FluxTypographyReset boundary so foreign
+// components dropped into an article keep their own styling.
+$guard: ':not(:where([data-flux-prose-reset], [data-flux-prose-reset] *))';
+$rhythm: ':where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, img, pre, table, [data-typography-aware])';
+
+.container {
+    max-width: var(--flux-typography-container, 90ch);
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.typography {
+    line-height: 1.6;
+    color: var(--foreground);
+
+    // Vertical rhythm between flow elements.
+    #{$rhythm} + :where(h1, h2, h3)#{$guard} {
+        margin-top: 33px;
+    }
+
+    #{$rhythm} + :where(h4, h5, h6, p, ul, ol, blockquote, img, pre, table)#{$guard} {
+        margin-top: 12px;
+    }
+
+    #{$rhythm} + :where([data-typography-aware]) {
+        margin-top: 21px;
+    }
+
+    // Headings.
+    :where(h1, h2)#{$guard} {
+        letter-spacing: -.01em;
+    }
+
+    h2#{$guard} {
+        padding-bottom: 9px;
+        border-bottom: 1px solid var(--surface-stroke);
+    }
+
+    // Lists.
+    :where(ul, ol)#{$guard} {
+        padding-left: 24px;
+    }
+
+    ul#{$guard} {
+        list-style: disc;
+    }
+
+    ol#{$guard} {
+        list-style: decimal;
+    }
+
+    :where(ul, ol) ul#{$guard} {
+        list-style-type: circle;
+    }
+
+    :where(ul, ol) ol#{$guard} {
+        list-style-type: lower-alpha;
+    }
+
+    li + li#{$guard} {
+        margin-top: 6px;
+    }
+
+    li > :where(ul, ol)#{$guard} {
+        margin-top: 6px;
+    }
+
+    // Blockquote.
+    blockquote#{$guard} {
+        font-style: italic;
+        padding-left: 18px;
+        color: var(--gray-600);
+        border-left: 3px solid var(--surface-stroke);
+    }
+
+    // Inline code and sample output.
+    :where(code, samp):not(pre code)#{$guard} {
+        font-size: .875em;
+        padding: 3px 6px;
+        border-radius: var(--radius-half);
+        background: var(--gray-100);
+    }
+
+    // Code block.
+    pre#{$guard} {
+        overflow-x: auto;
+        padding: 15px 18px;
+        border-radius: var(--radius);
+        background: var(--gray-100);
+    }
+
+    pre code {
+        font-size: inherit;
+        padding: 0;
+        background: none;
+    }
+
+    // Keyboard key.
+    kbd#{$guard} {
+        font-size: .8125em;
+        padding: 3px 6px;
+        border: 1px solid var(--surface-stroke);
+        border-radius: var(--radius-half);
+        box-shadow: 0 1px 0 var(--surface-stroke);
+    }
+
+    // Divider.
+    hr#{$guard} {
+        margin: 33px 0;
+        border: 0;
+        border-top: 1px solid var(--surface-stroke);
+    }
+
+    // Table, matching the FluxTable component.
+    table#{$guard} {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: start;
+    }
+
+    :where(th, td)#{$guard} {
+        padding: 12px 15px;
+        text-align: start;
+        word-break: break-word;
+    }
+
+    :where(th, td) + :where(th, td)#{$guard} {
+        border-left: 1px solid var(--gray-100);
+    }
+
+    tr + tr > :where(th, td)#{$guard} {
+        border-top: 1px solid var(--gray-100);
+    }
+
+    thead th#{$guard} {
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--foreground-prominent);
+        border-bottom: 2px solid var(--gray-100);
+        background: var(--gray-50);
+    }
+
+    // Image.
+    img#{$guard} {
+        height: unset;
+        border-radius: var(--radius-half);
+        outline: 1px solid rgb(0 0 0 / .025);
+        outline-offset: -1px;
+    }
+}

--- a/packages/components/src/css/component/Typography.module.scss
+++ b/packages/components/src/css/component/Typography.module.scss
@@ -121,7 +121,7 @@ $rhythm: ':where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, img, pre, ta
     :where(th, td)#{$guard} {
         padding: 12px 15px;
         text-align: start;
-        word-break: break-word;
+        overflow-wrap: break-word;
     }
 
     :where(th, td) + :where(th, td)#{$guard} {

--- a/packages/components/src/css/reset.scss
+++ b/packages/components/src/css/reset.scss
@@ -9,6 +9,12 @@
         margin: 0;
     }
 
+    // Remove default list styling; rich prose re-adds it inside FluxTypography.
+    ul, ol {
+        padding: 0;
+        list-style: none;
+    }
+
     body {
         // Accessible line-height.
         line-height: 1.5;

--- a/packages/components/src/css/typography.scss
+++ b/packages/components/src/css/typography.scss
@@ -56,44 +56,7 @@
         font-size: 14px;
     }
 
-    blockquote {
-        position: relative;
-        margin-left: 30px;
-        padding: 15px 21px;
-        background: var(--gray-100);
-        border-radius: var(--radius);
-
-        &::before {
-            position: absolute;
-            top: 5px;
-            left: -27px;
-            content: '”';
-            color: var(--primary-600);
-            font-size: 39px;
-            font-weight: 700;
-        }
-    }
-
     code, kbd, samp, pre {
         font-family: var(--font-monospace), monospace;
-    }
-
-    img:not([class]) {
-        height: unset;
-        border-radius: var(--radius-half);
-        outline: 1px solid rgb(0 0 0 / .025);
-        outline-offset: -1px;
-    }
-
-    :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, img, [data-typography-aware]) + :where(h1, h2, h3) {
-        margin-top: 33px;
-    }
-
-    :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, img, [data-typography-aware]) + :where(h4, h5, h6, p, ul, ol, li, blockquote, img) {
-        margin-top: 12px;
-    }
-
-    :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, img, [data-typography-aware]) + :where([data-typography-aware]) {
-        margin-top: 21px;
     }
 }


### PR DESCRIPTION
## Summary

Introduces `FluxTypography`, a prose wrapper that scopes Flux's rich typographic system so it only applies to opted-in document content. Outside the component, only light element defaults remain: heading sizes, links and the monospace font.

## What changed

**New components**
- `FluxTypography` — prose wrapper with `tag`, `as-child` and `container` props. `container` caps the content at a centered reading measure via `--flux-typography-container` (default `90ch`).
- `FluxTypographyReset` — opts a nested subtree out of the prose styling (e.g. a Flux component dropped into an article) while it keeps flowing in the vertical rhythm.

**Styling**
- Moved the vertical rhythm, decorated blockquote and image treatment out of the global stylesheet into `.typography`.
- Kept light element defaults global (heading sizes/weights, links, monospace, `small`).
- Reset bare `ul`/`ol` styling globally; rich lists return inside the component.
- Aligned the prose table with the `FluxTable` component (borders, header, padding, left-aligned headers).

**Docs**
- New `Typography` component page with runnable examples (headings, paragraphs, lists, blockquote, code, table, reset, full article).
- Wrapped the guide examples in `FluxTypography` and migrated the flyout demo.
- VitePress theme carve-outs (`[data-flux-typography]`) so previews render with the real Flux typography instead of the docs theme's prose styling.

## Breaking change

The automatic vertical spacing between bare headings, paragraphs, lists, blockquotes and images no longer applies globally. Wrap document content in `<FluxTypography>` to restore it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Typography component for consistent styling of headings, paragraphs, lists, quotes, code, tables, and images.
  * Added Typography Reset support for preserving custom content styling.
  * Added configurable element tags, content width, and wrapper-free rendering.
  * Added comprehensive Typography documentation, examples, and live previews.

* **Bug Fixes**
  * Prevented documentation styles from overriding content rendered through Typography.
  * Improved default list reset behavior for more predictable styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->