### PR TITLE
refactor: align components with the vue-component-anatomy standard

### DIFF
--- a/packages/application/src/component/FluxApplication.vue
+++ b/packages/application/src/component/FluxApplication.vue
@@ -43,18 +43,49 @@
     let readyFrame: number | undefined;
     let resizeTimer: ReturnType<typeof setTimeout> | undefined;
 
+    const contextStack = shallowRef<FluxApplicationContextInfo[]>([]);
+    const layout = ref<FluxApplicationLayout>('default');
+    const viewIndex = ref(0);
+
     const isMenuCollapsed = useRemembered('application-menu-collapsed', true);
     const matchedMenuRoutes = useNamedRoutes(toRef(() => contextMenuName));
     const route = useRoute();
     const {lg, xl} = useBreakpoints();
 
-    const contextStack = shallowRef<FluxApplicationContextInfo[]>([]);
-    const layout = ref<FluxApplicationLayout>('default');
-    const viewIndex = ref(0);
-
     const activeContext = computed(() => contextStack.value.at(-1));
     const contexts = computed(() => contextStack.value);
     const totalLevels = computed(() => 1 + matchedMenuRoutes.value.length);
+
+    watch(() => route.fullPath, () => {
+        viewIndex.value = totalLevels.value - 1;
+
+        if (!lg.value && !xl.value) {
+            isMenuCollapsed.value = true;
+        }
+    });
+
+    watch(totalLevels, (next) => {
+        viewIndex.value = clampViewIndex(viewIndex.value);
+
+        // On initial route resolve, totalLevels jumps from 1 to its
+        // real value. Snap to the deepest level so the user lands on
+        // the right context without seeing a slide animation.
+        if (viewIndex.value === 0 && next > 1) {
+            viewIndex.value = next - 1;
+        }
+    }, {immediate: true});
+
+    watch(isMenuCollapsed, collapsed => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        if (collapsed) {
+            delete document.documentElement.dataset.applicationMenuOpen;
+        } else {
+            document.documentElement.dataset.applicationMenuOpen = '';
+        }
+    }, {immediate: true});
 
     onMounted(() => {
         if (typeof window === 'undefined') {
@@ -163,37 +194,6 @@
         stack[index] = {id, ...info};
         contextStack.value = stack;
     }
-
-    watch(() => route.fullPath, () => {
-        viewIndex.value = totalLevels.value - 1;
-
-        if (!lg.value && !xl.value) {
-            isMenuCollapsed.value = true;
-        }
-    });
-
-    watch(totalLevels, (next) => {
-        viewIndex.value = clampViewIndex(viewIndex.value);
-
-        // On initial route resolve, totalLevels jumps from 1 to its
-        // real value. Snap to the deepest level so the user lands on
-        // the right context without seeing a slide animation.
-        if (viewIndex.value === 0 && next > 1) {
-            viewIndex.value = next - 1;
-        }
-    }, {immediate: true});
-
-    watch(isMenuCollapsed, collapsed => {
-        if (typeof document === 'undefined') {
-            return;
-        }
-
-        if (collapsed) {
-            delete document.documentElement.dataset.applicationMenuOpen;
-        } else {
-            document.documentElement.dataset.applicationMenuOpen = '';
-        }
-    }, {immediate: true});
 
     provide(FluxApplicationInjectionKey, {
         activeContext,

--- a/packages/components/src/component/FluxAvatarGroup.vue
+++ b/packages/components/src/component/FluxAvatarGroup.vue
@@ -66,8 +66,10 @@
         return names.length > 0 ? names.join(', ') : overflowLabel.value;
     });
 
-    const renderVisible = () => visibleChildren.value.map((vnode, index) => h('span', {
-        class: $style.avatarGroupItem,
-        key: vnode.key ?? index
-    }, [vnode]));
+    function renderVisible(): VNode[] {
+        return visibleChildren.value.map((vnode, index) => h('span', {
+            class: $style.avatarGroupItem,
+            key: vnode.key ?? index
+        }, [vnode]));
+    }
 </script>

--- a/packages/components/src/component/FluxBadgeGroup.vue
+++ b/packages/components/src/component/FluxBadgeGroup.vue
@@ -100,6 +100,11 @@
             });
     }
 
-    const renderStart = () => renderBadges(slots.start?.());
-    const renderEnd = () => renderBadges(slots.end?.());
+    function renderStart(): VNode[] {
+        return renderBadges(slots.start?.());
+    }
+
+    function renderEnd(): VNode[] {
+        return renderBadges(slots.end?.());
+    }
 </script>

--- a/packages/components/src/component/FluxBreadcrumb.vue
+++ b/packages/components/src/component/FluxBreadcrumb.vue
@@ -94,12 +94,25 @@
 
     // Re-read the slot on every access rather than memoising: a route-driven trail
     // swaps its items reactively and a cached VNode list would go stale.
-    const collectItems = (): VNode[] => flattenVNodeTree(slots.default?.() ?? []);
-    const startCount = (): number => collapse === 'middle' ? 1 : 0;
+    function collectItems(): VNode[] {
+        return flattenVNodeTree(slots.default?.() ?? []);
+    }
 
-    const visibleStartItems = (): VNode[] => hasCollapse.value ? collectItems().slice(0, startCount()) : collectItems();
-    const collapsedItems = (): VNode[] => hasCollapse.value ? collectItems().slice(startCount(), tailStart.value) : [];
-    const visibleEndItems = (): VNode[] => hasCollapse.value ? collectItems().slice(tailStart.value) : [];
+    function startCount(): number {
+        return collapse === 'middle' ? 1 : 0;
+    }
+
+    function visibleStartItems(): VNode[] {
+        return hasCollapse.value ? collectItems().slice(0, startCount()) : collectItems();
+    }
+
+    function collapsedItems(): VNode[] {
+        return hasCollapse.value ? collectItems().slice(startCount(), tailStart.value) : [];
+    }
+
+    function visibleEndItems(): VNode[] {
+        return hasCollapse.value ? collectItems().slice(tailStart.value) : [];
+    }
 
     const reflow = animationFrameDebounce(() => {
         if (collapse === 'none') {
@@ -181,9 +194,9 @@
         });
     }, {immediate: true});
 
+    watch(() => collapse, reflow);
+
     // A changed trail (added/removed/reordered items) re-renders the hidden measurer
     // without necessarily resizing it, so re-run the fit after every update too.
     onUpdated(reflow);
-
-    watch(() => collapse, reflow);
 </script>

--- a/packages/components/src/component/FluxCalendar.vue
+++ b/packages/components/src/component/FluxCalendar.vue
@@ -181,24 +181,6 @@
     import $style from '~flux/components/css/component/Calendar.module.scss';
     import $styleDatePicker from '~flux/components/css/component/DatePicker.module.scss';
 
-    const SNAP_MINUTES = 30;
-    const NAV_HOVER_INITIAL_DELAY_MS = 700;
-    const NAV_HOVER_REPEAT_DELAY_MS = 450;
-
-    const MONTH_KEY_DELTAS = {
-        left: {day: -1},
-        right: {day: 1},
-        up: {day: -7},
-        down: {day: 7}
-    } as const;
-
-    const TIME_GRID_KEY_DELTAS = {
-        left: {day: -1},
-        right: {day: 1},
-        up: {minute: -SNAP_MINUTES},
-        down: {minute: SNAP_MINUTES}
-    } as const;
-
     const emit = defineEmits<{
         navigate: [DateTime, DateTime, DateTime];
         reschedule: [{ id: string | number; fromDate: DateTime; toDate: DateTime }];
@@ -228,6 +210,35 @@
     const slots = defineSlots<{
         default?(): VNode[];
     }>();
+
+    const SNAP_MINUTES = 30;
+    const NAV_HOVER_INITIAL_DELAY_MS = 700;
+    const NAV_HOVER_REPEAT_DELAY_MS = 450;
+
+    const MONTH_KEY_DELTAS = {
+        left: {day: -1},
+        right: {day: 1},
+        up: {day: -7},
+        down: {day: 7}
+    } as const;
+
+    const TIME_GRID_KEY_DELTAS = {
+        left: {day: -1},
+        right: {day: 1},
+        up: {minute: -SNAP_MINUTES},
+        down: {minute: SNAP_MINUTES}
+    } as const;
+
+    // Items registry — items registreren zichzelf via inject.
+    const items = shallowRef<FluxCalendarItemData[]>([]);
+
+    // Drag-state.
+    const dragState = ref<{ readonly id: string | number; readonly fromDate: DateTime } | null>(null);
+    const grabbedId = ref<string | number | null>(null);
+    const monthFocusedDate = ref<DateTime | null>(null);
+    const itemElementRegistry = new WeakMap<Element, { readonly id: string | number }>();
+    const itemElementsById = new Map<string | number, Element>();
+    let navHoverTimer: ReturnType<typeof setTimeout> | null = null;
 
     const translate = useTranslate();
     const {md, lg, xl} = useBreakpoints();
@@ -306,17 +317,6 @@
         next: nextTimeGrid,
         previous: previousTimeGrid
     } = useCalendarTimeGrid(initialDate, timeGridDayCount);
-
-    // Items registry — items registreren zichzelf via inject.
-    const items = shallowRef<FluxCalendarItemData[]>([]);
-
-    // Drag-state.
-    const dragState = ref<{ readonly id: string | number; readonly fromDate: DateTime } | null>(null);
-    const grabbedId = ref<string | number | null>(null);
-    const monthFocusedDate = ref<DateTime | null>(null);
-    const itemElementRegistry = new WeakMap<Element, { readonly id: string | number }>();
-    const itemElementsById = new Map<string | number, Element>();
-    let navHoverTimer: ReturnType<typeof setTimeout> | null = null;
 
     function restoreItemFocus(id: string | number): void {
         requestAnimationFrame(() => {
@@ -648,15 +648,6 @@
         emit('dragEnd', {id: drag.id});
     }
 
-    onMounted(() => {
-        document.addEventListener('dragend', onDocumentDragEnd);
-    });
-
-    onBeforeUnmount(() => {
-        document.removeEventListener('dragend', onDocumentDragEnd);
-        cancelNavHoverTimer();
-    });
-
     // Navigate-event aggregation.
     watch([
         () => unref(resolvedView),
@@ -675,5 +666,14 @@
     watch(() => initialDate, (d) => {
         setMonthViewDateRaw(d);
         setTimeGridViewDate(d);
+    });
+
+    onMounted(() => {
+        document.addEventListener('dragend', onDocumentDragEnd);
+    });
+
+    onBeforeUnmount(() => {
+        document.removeEventListener('dragend', onDocumentDragEnd);
+        cancelNavHoverTimer();
     });
 </script>

--- a/packages/components/src/component/FluxCalendarItem.vue
+++ b/packages/components/src/component/FluxCalendarItem.vue
@@ -1,3 +1,9 @@
+<template>
+    <span
+        aria-hidden="true"
+        style="display: none"/>
+</template>
+
 <script
     lang="ts"
     setup>
@@ -24,30 +30,6 @@
     const instance = getCurrentInstance();
     const isClickable = computed(() => !!instance?.vnode?.props?.onClick);
 
-    function buildData() {
-        return {
-            id: props.id as string | number,
-            date: props.date,
-            duration: props.duration,
-            allDay: props.allDay ?? false,
-            isClickable: isClickable.value,
-            renderContent: () => slots.default?.() ?? [],
-            handleClick: (evt: MouseEvent) => emit('click', evt)
-        };
-    }
-
-    onMounted(() => {
-        if (dragContext && props.id != null) {
-            dragContext.registerItem(props.id, buildData());
-        }
-    });
-
-    onBeforeUnmount(() => {
-        if (dragContext && props.id != null) {
-            dragContext.unregisterItem(props.id);
-        }
-    });
-
     watch(() => props.id, (newId, oldId) => {
         if (!dragContext) {
             return;
@@ -70,10 +52,28 @@
             }
         }
     );
-</script>
 
-<template>
-    <span
-        aria-hidden="true"
-        style="display: none"/>
-</template>
+    onMounted(() => {
+        if (dragContext && props.id != null) {
+            dragContext.registerItem(props.id, buildData());
+        }
+    });
+
+    onBeforeUnmount(() => {
+        if (dragContext && props.id != null) {
+            dragContext.unregisterItem(props.id);
+        }
+    });
+
+    function buildData() {
+        return {
+            id: props.id as string | number,
+            date: props.date,
+            duration: props.duration,
+            allDay: props.allDay ?? false,
+            isClickable: isClickable.value,
+            renderContent: () => slots.default?.() ?? [],
+            handleClick: (evt: MouseEvent) => emit('click', evt)
+        };
+    }
+</script>

--- a/packages/components/src/component/FluxColorPicker.vue
+++ b/packages/components/src/component/FluxColorPicker.vue
@@ -167,8 +167,6 @@
         readonly type?: 'hex' | 'rgb' | 'hsl' | 'hsv';
     }>();
 
-    const translate = useTranslate();
-
     const hexInput = ref('');
     const hsv = ref<[number, number, number]>([0, 0, 0]);
     const isDragging = ref(false);
@@ -178,34 +176,13 @@
     // feedback loop with rounding drift.
     let lastEmitted: string | null = null;
 
+    const translate = useTranslate();
+
     const rgb = computed(() => {
         const [r, g, b] = hsvToRGB(...unref(hsv));
 
         return `rgb(${r} ${g} ${b} / ${unref(alpha)})`;
     });
-
-    function clampByte(value: number): number {
-        return Math.max(0, Math.min(255, Math.round(value)));
-    }
-
-    function alphaToHex(value: number): string {
-        return clampByte(value * 255).toString(16).padStart(2, '0');
-    }
-
-    function hsvToHex(hsv: [number, number, number]): string {
-        const hex = rgbToHEX(...hsvToRGB(...hsv));
-
-        return isAlphaEnabled ? hex + alphaToHex(unref(alpha)) : hex;
-    }
-
-    function expandHex(hex: string): string {
-        // Expand shorthand (#rgb / #rgba) to full form (#rrggbb / #rrggbbaa).
-        if (hex.length === 4 || hex.length === 5) {
-            return '#' + hex.slice(1).split('').map(char => char + char).join('');
-        }
-
-        return hex;
-    }
 
     const hue = computed({
         get: () => unref(hsv)[0] * 360,
@@ -247,39 +224,6 @@
     const rgbInputR = generateComputedInput(0, hsvToRGB, rgbToHSV);
     const rgbInputG = generateComputedInput(1, hsvToRGB, rgbToHSV);
     const rgbInputB = generateComputedInput(2, hsvToRGB, rgbToHSV);
-
-    function onDragging(is: boolean): void {
-        isDragging.value = is;
-    }
-
-    function onHexBlur(): void {
-        const hex = unref(hexInput).trim();
-
-        if (/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(hex)) {
-            const expanded = expandHex(hex);
-
-            hsv.value = rgbToHSV(...hexToRGB(expanded.slice(0, 7)));
-
-            if (isAlphaEnabled && expanded.length === 9) {
-                alpha.value = parseInt(expanded.slice(7, 9), 16) / 255;
-            }
-
-            hexInput.value = hsvToHex(unref(hsv));
-        } else {
-            hexInput.value = hsvToHex(unref(hsv));
-        }
-    }
-
-    function generateComputedInput(index: number, fromHSV?: (a: number, b: number, c: number) => [number, number, number], toHSV?: (a: number, b: number, c: number) => [number, number, number]): ComputedRef<number> {
-        return computed({
-            get: () => fromHSV?.(...unref(hsv))[index] ?? unref(hsv)[index],
-            set: value => {
-                const values: [number, number, number] = [...(fromHSV?.(...unref(hsv)) ?? unref(hsv))];
-                values[index] = value;
-                hsv.value = toHSV?.(...values) ?? values;
-            }
-        });
-    }
 
     watch(modelValue, (modelValue, oldModelValue) => {
         if (unref(isDragging)) {
@@ -349,4 +293,60 @@
         lastEmitted = JSON.stringify(next);
         modelValue.value = next;
     });
+
+    function clampByte(value: number): number {
+        return Math.max(0, Math.min(255, Math.round(value)));
+    }
+
+    function alphaToHex(value: number): string {
+        return clampByte(value * 255).toString(16).padStart(2, '0');
+    }
+
+    function hsvToHex(hsv: [number, number, number]): string {
+        const hex = rgbToHEX(...hsvToRGB(...hsv));
+
+        return isAlphaEnabled ? hex + alphaToHex(unref(alpha)) : hex;
+    }
+
+    function expandHex(hex: string): string {
+        // Expand shorthand (#rgb / #rgba) to full form (#rrggbb / #rrggbbaa).
+        if (hex.length === 4 || hex.length === 5) {
+            return '#' + hex.slice(1).split('').map(char => char + char).join('');
+        }
+
+        return hex;
+    }
+
+    function onDragging(is: boolean): void {
+        isDragging.value = is;
+    }
+
+    function onHexBlur(): void {
+        const hex = unref(hexInput).trim();
+
+        if (/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(hex)) {
+            const expanded = expandHex(hex);
+
+            hsv.value = rgbToHSV(...hexToRGB(expanded.slice(0, 7)));
+
+            if (isAlphaEnabled && expanded.length === 9) {
+                alpha.value = parseInt(expanded.slice(7, 9), 16) / 255;
+            }
+
+            hexInput.value = hsvToHex(unref(hsv));
+        } else {
+            hexInput.value = hsvToHex(unref(hsv));
+        }
+    }
+
+    function generateComputedInput(index: number, fromHSV?: (a: number, b: number, c: number) => [number, number, number], toHSV?: (a: number, b: number, c: number) => [number, number, number]): ComputedRef<number> {
+        return computed({
+            get: () => fromHSV?.(...unref(hsv))[index] ?? unref(hsv)[index],
+            set: value => {
+                const values: [number, number, number] = [...(fromHSV?.(...unref(hsv)) ?? unref(hsv))];
+                values[index] = value;
+                hsv.value = toHSV?.(...values) ?? values;
+            }
+        });
+    }
 </script>

--- a/packages/components/src/component/FluxColorSelect.vue
+++ b/packages/components/src/component/FluxColorSelect.vue
@@ -86,12 +86,22 @@
         readonly isCustomAllowed?: boolean;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const swatchesRef = useTemplateRef<HTMLButtonElement[]>('swatches');
-    const translate = useTranslate();
-
     const customColor = ref('#000000');
     const focusedIndex = ref(0);
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const translate = useTranslate();
+
+    watch(modelValue, value => {
+        customColor.value = value;
+
+        const selectedIndex = colors.indexOf(value);
+
+        if (selectedIndex !== -1) {
+            focusedIndex.value = selectedIndex;
+        }
+    }, {immediate: true});
 
     function select(color: string, close?: () => void): void {
         if (unref(disabled)) {
@@ -139,14 +149,4 @@
 
         evt.preventDefault();
     }
-
-    watch(modelValue, value => {
-        customColor.value = value;
-
-        const selectedIndex = colors.indexOf(value);
-
-        if (selectedIndex !== -1) {
-            focusedIndex.value = selectedIndex;
-        }
-    }, {immediate: true});
 </script>

--- a/packages/components/src/component/FluxCommandPalette.vue
+++ b/packages/components/src/component/FluxCommandPalette.vue
@@ -110,7 +110,7 @@
                             <FluxCommandPaletteItem
                                 v-for="(action, index) of subActions"
                                 :id="optionId(index)"
-                                :key="index"
+                                :key="action.label"
                                 ref="itemRefs"
                                 :icon="action.icon"
                                 :is-highlighted="highlightedIndex === index"
@@ -178,26 +178,23 @@
     import FluxTag from './FluxTag.vue';
     import $style from '~flux/components/css/component/CommandPalette.module.scss';
 
+    const emit = defineEmits<{
+        select: [item: FluxCommandSourceItem];
+    }>();
+
     const props = defineProps<{
         readonly hasKeyboardShortcut?: boolean;
         readonly placeholder?: string;
         readonly sources: FluxCommandSource[];
     }>();
 
-    const emit = defineEmits<{
-        select: [item: FluxCommandSourceItem];
-    }>();
-
-    const translate = useTranslate();
-
     const dialogRef = useTemplateRef<HTMLDivElement>('dialogRef');
     const inputRef = useTemplateRef<HTMLInputElement>('inputRef');
-    const itemRefs = ref<InstanceType<typeof FluxCommandPaletteItem>[]>();
+    const itemRefs = useTemplateRef<InstanceType<typeof FluxCommandPaletteItem>[]>('itemRefs');
 
     // Combobox wiring: the input owns the focus and points at the active option through
     // aria-activedescendant, so each rendered option needs a stable, unique id derived from this base.
     const listboxId = useId();
-    const optionId = (index: number) => `${listboxId}-option-${index}`;
 
     const isOpen = ref(false);
     const isClosing = ref(false);
@@ -206,15 +203,7 @@
 
     const dialogRegistration = ref<FluxDialogRegistration | null>(null);
 
-    const zIndexBase = computed(() => {
-        const registration = unref(dialogRegistration);
-
-        if (!registration) {
-            return null;
-        }
-
-        return 10001 + registration.getPosition() * 2;
-    });
+    const translate = useTranslate();
 
     useFocusTrap(dialogRef);
 
@@ -240,12 +229,41 @@
         itemRefs
     });
 
+    useHotKey('mod+k', () => {
+        if (unref(isOpen) && !unref(isClosing)) {
+            close();
+        } else {
+            open();
+        }
+    }, {
+        enabled: () => props.hasKeyboardShortcut
+    });
+
+    const zIndexBase = computed(() => {
+        const registration = unref(dialogRegistration);
+
+        if (!registration) {
+            return null;
+        }
+
+        return 10001 + registration.getPosition() * 2;
+    });
+
     const isExpanded = computed(() => unref(totalItems) > 0);
     const activeDescendant = computed(() => {
         const index = unref(highlightedIndex);
 
         return isExpanded.value && index >= 0 ? optionId(index) : undefined;
     });
+
+    onUnmounted(() => {
+        dialogRegistration.value?.unregister();
+        dialogRegistration.value = null;
+    });
+
+    function optionId(index: number): string {
+        return `${listboxId}-option-${index}`;
+    }
 
     function open(): void {
         pendingClose?.();
@@ -339,21 +357,6 @@
             close();
         });
     }
-
-    onUnmounted(() => {
-        dialogRegistration.value?.unregister();
-        dialogRegistration.value = null;
-    });
-
-    useHotKey('mod+k', () => {
-        if (unref(isOpen) && !unref(isClosing)) {
-            close();
-        } else {
-            open();
-        }
-    }, {
-        enabled: () => props.hasKeyboardShortcut
-    });
 
     defineExpose({
         close,

--- a/packages/components/src/component/FluxComment.vue
+++ b/packages/components/src/component/FluxComment.vue
@@ -63,20 +63,10 @@
         default(): VNode[];
     }>();
 
-    const translate = useTranslate();
-
     const timeTick = ref(0);
     let timeTickInterval: ReturnType<typeof setInterval> | undefined;
 
-    onMounted(() => {
-        timeTickInterval = setInterval(() => {
-            timeTick.value++;
-        }, 30000);
-    });
-
-    onBeforeUnmount(() => {
-        clearInterval(timeTickInterval);
-    });
+    const translate = useTranslate();
 
     const isJustNowVisible = computed(() => {
         void timeTick.value;
@@ -86,5 +76,15 @@
     const relative = computed(() => {
         void timeTick.value;
         return postedOn?.toRelative() ?? null;
+    });
+
+    onMounted(() => {
+        timeTickInterval = setInterval(() => {
+            timeTick.value++;
+        }, 30000);
+    });
+
+    onBeforeUnmount(() => {
+        clearInterval(timeTickInterval);
     });
 </script>

--- a/packages/components/src/component/FluxContextMenu.vue
+++ b/packages/components/src/component/FluxContextMenu.vue
@@ -38,6 +38,11 @@
     import { FluxFadeTransition } from '~flux/components/transition';
     import $style from '~flux/components/css/component/ContextMenu.module.scss';
 
+    const emit = defineEmits<{
+        open: [MouseEvent];
+        close: [];
+    }>();
+
     const {
         debugCone = false,
         disabled: componentDisabled,
@@ -55,11 +60,6 @@
             | 'bottom' | 'bottom-left' | 'bottom-right';
     }>();
 
-    const emit = defineEmits<{
-        open: [MouseEvent];
-        close: [];
-    }>();
-
     defineSlots<{
         default(): VNode[];
         menu(props: {close(): void}): VNode[];
@@ -70,7 +70,6 @@
     const LONG_PRESS_DURATION = 500;
     const MOVE_TOLERANCE = 10;
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const popupRef = useTemplateRef<ComponentPublicInstance>('popup');
 
     const isOpen = ref(false);
@@ -86,6 +85,8 @@
         }
     } as unknown as ComponentPublicInstance;
 
+    const disabled = useDisabled(toRef(() => componentDisabled));
+
     const menuFlyout = useMenuFlyoutProvider({
         debugCone: toRef(() => debugCone),
         onCloseAll: () => close()
@@ -96,6 +97,10 @@
     useFocusTrap(popupRef, {
         disable: computed(() => menuFlyout.keyboardStack.value.length > 0)
     });
+
+    const dismissTarget = computed(() => isOpen.value ? window : null);
+
+    onUnmounted(cancelLongPress);
 
     function onContextMenu(evt: MouseEvent): void {
         if (disabled.value) {
@@ -162,8 +167,6 @@
         }, LONG_PRESS_DURATION);
     }
 
-    onUnmounted(cancelLongPress);
-
     function close(): void {
         if (!isOpen.value) {
             return;
@@ -178,8 +181,6 @@
 
         return (!!root && !!target && root.contains(target)) || menuFlyout.isInsidePopups(target);
     }
-
-    const dismissTarget = computed(() => isOpen.value ? window : null);
 
     if (!isSSR) {
         useEventListener(dismissTarget, 'pointerdown', (evt: PointerEvent) => {

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -170,7 +170,7 @@
     generic="T extends Record<string, any>">
     import { clsx } from 'clsx';
     import { computed, getCurrentInstance, unref, useTemplateRef, type VNode, watch } from 'vue';
-    import FluxTableActions from '~flux/components/component/FluxTableActions.vue';
+    import FluxTableActions from './FluxTableActions.vue';
     import { useDisabledInjection } from '~flux/components/composable';
     import { useTranslate } from '~flux/components/composable/private';
     import FluxAction from './FluxAction.vue';

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -117,7 +117,7 @@
                         </FluxTableActions>
                     </FluxTableCell>
 
-                    <template v-for="(_, name) of slots">
+                    <template v-for="(_, name) of slots" :key="name">
                         <slot
                             v-if="!IGNORED_SLOTS.includes(name as string)"
                             v-bind="{index: entry.index, item: entry.item, items: limitedItems, page, perPage, total, isSelected: isItemSelected(entry.item)}"
@@ -170,6 +170,7 @@
     generic="T extends Record<string, any>">
     import { clsx } from 'clsx';
     import { computed, getCurrentInstance, unref, useTemplateRef, type VNode, watch } from 'vue';
+    import FluxTableActions from '~flux/components/component/FluxTableActions.vue';
     import { useDisabledInjection } from '~flux/components/composable';
     import { useTranslate } from '~flux/components/composable/private';
     import FluxAction from './FluxAction.vue';
@@ -182,7 +183,6 @@
     import FluxTableRow from './FluxTableRow.vue';
     import { PassThrough } from './primitive';
     import $style from '~flux/components/css/component/Table.module.scss';
-    import FluxTableActions from '~flux/components/component/FluxTableActions.vue';
 
     type SelectionId = string | number;
     type SelectionValue = SelectionId | null | SelectionId[];
@@ -424,10 +424,6 @@
     const selectedCount = computed(() => unref(selectedIds).length);
     const hasSelectionBar = computed(() => 'selection' in slots && unref(selectedCount) > 0);
 
-    function clearSelection(): void {
-        selected.value = selectionMode === 'multiple' ? [] : null;
-    }
-
     const selectAllState = computed<boolean | null>(() => {
         const ids = unref(currentPageIds);
         const value = unref(selected);
@@ -449,6 +445,14 @@
 
         return null;
     });
+
+    watch(() => items, () => {
+        unref(table)?.$el.scrollTo(0, 0);
+    });
+
+    function clearSelection(): void {
+        selected.value = selectionMode === 'multiple' ? [] : null;
+    }
 
     function getItemId(item: T): SelectionId | undefined {
         if (!uniqueKey) {
@@ -579,8 +583,4 @@
     if (import.meta.env.DEV && unref(hasExpandable) && !uniqueKey) {
         console.warn('[FluxDataTable] `uniqueKey` is required when the `expandable` slot is used, otherwise rows cannot be tracked across renders.');
     }
-
-    watch(() => items, () => {
-        unref(table)?.$el.scrollTo(0, 0);
-    });
 </script>

--- a/packages/components/src/component/FluxDropZone.vue
+++ b/packages/components/src/component/FluxDropZone.vue
@@ -108,14 +108,24 @@
     }>();
 
     const contentRef = useTemplateRef('content');
-    const disabled = useDisabled(toRef(() => componentDisabled));
-    const translate = useTranslate();
 
     const isDragging = ref(false);
     const isDraggingOver = ref(false);
     const pathLength = ref(0);
 
     let dragDepth = 0;
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const translate = useTranslate();
+
+    watch(contentRef, content => {
+        if (!content) {
+            return;
+        }
+
+        const {width, height} = content.getBoundingClientRect();
+        pathLength.value = roundStep(width * 2 + height * 2, 6);
+    }, {immediate: true});
 
     onMounted(() => {
         window.addEventListener('dragleave', onWindowDragEnd, {capture: true});
@@ -287,13 +297,4 @@
         input.addEventListener('change', onFileSelected, {once: true});
         input.showPicker();
     }
-
-    watch(contentRef, content => {
-        if (!content) {
-            return;
-        }
-
-        const {width, height} = content.getBoundingClientRect();
-        pathLength.value = roundStep(width * 2 + height * 2, 6);
-    }, {immediate: true});
 </script>

--- a/packages/components/src/component/FluxExpandable.vue
+++ b/packages/components/src/component/FluxExpandable.vue
@@ -102,6 +102,14 @@
 
     const expandIcon = computed<FluxIconName>(() => unref(isOpen) ? 'minus' : 'plus');
 
+    watch(() => isOpened, () => {
+        if (isOpened) {
+            open();
+        } else {
+            close();
+        }
+    }, {immediate: true});
+
     onBeforeMount(() => register?.(componentId.value, instance));
     onUnmounted(() => unregister?.(componentId.value));
 
@@ -131,14 +139,6 @@
             open();
         }
     }
-
-    watch(() => isOpened, () => {
-        if (isOpened) {
-            open();
-        } else {
-            close();
-        }
-    }, {immediate: true});
 
     defineExpose({
         contentId,

--- a/packages/components/src/component/FluxFader.vue
+++ b/packages/components/src/component/FluxFader.vue
@@ -88,6 +88,18 @@
         }
     });
 
+    watch([isActive, () => interval], start, {immediate: true});
+
+    watch(current, value => {
+        if (value < 0 || value >= count.value) {
+            return;
+        }
+
+        emit('update', value);
+    });
+
+    onScopeDispose(stop);
+
     function next(): void {
         if (count.value === 0) {
             return;
@@ -120,16 +132,4 @@
 
         timer = setInterval(() => next(), interval);
     }
-
-    watch([isActive, () => interval], start, {immediate: true});
-
-    watch(current, value => {
-        if (value < 0 || value >= count.value) {
-            return;
-        }
-
-        emit('update', value);
-    });
-
-    onScopeDispose(stop);
 </script>

--- a/packages/components/src/component/FluxFilterBase.vue
+++ b/packages/components/src/component/FluxFilterBase.vue
@@ -32,12 +32,6 @@
         filters(): VNode[];
     }>();
 
-    function resolveDefinition(vnode: VNode): FluxFilterDefinition | null {
-        const factory = (vnode.type as { __filterDefinitionFactory?: (props: unknown) => FluxFilterDefinition })?.__filterDefinitionFactory;
-
-        return typeof factory === 'function' ? factory(getComponentProps(vnode)) : null;
-    }
-
     const flattenedFilters = computed(() => flattenVNodeTree(slots.filters?.() ?? []));
 
     const buttons = computed(() => {
@@ -106,6 +100,12 @@
             }
         }
     }, {immediate: true});
+
+    function resolveDefinition(vnode: VNode): FluxFilterDefinition | null {
+        const factory = (vnode.type as { __filterDefinitionFactory?: (props: unknown) => FluxFilterDefinition })?.__filterDefinitionFactory;
+
+        return typeof factory === 'function' ? factory(getComponentProps(vnode)) : null;
+    }
 
     function back(): void {
         emit('back');

--- a/packages/components/src/component/FluxFilterWindow.vue
+++ b/packages/components/src/component/FluxFilterWindow.vue
@@ -66,12 +66,12 @@
         readonly menuItems: (FluxFilterDefinition | VNode)[][];
     }>();
 
+    const rootRef = useTemplateRef<HTMLDivElement>('root');
+    const windowRef = useTemplateRef<{ back(to: string): void; }>('window');
+
     const {clear: clearFilter, getDefinition, getValue, reset: resetFilter} = useFilterInjection();
 
     const translate = useTranslate();
-
-    const rootRef = useTemplateRef<HTMLDivElement>('root');
-    const windowRef = useTemplateRef<{ back(to: string): void; }>('window');
 
     async function focusPanel(): Promise<void> {
         await nextTick();

--- a/packages/components/src/component/FluxFlyout.vue
+++ b/packages/components/src/component/FluxFlyout.vue
@@ -110,6 +110,21 @@
     let closeAnimationEndListener: ((evt: AnimationEvent) => void) | null = null;
     let openAnimationEndListener: ((evt: AnimationEvent) => void) | null = null;
 
+    watch(isOpen, (isOpen, _, onCleanup) => {
+        const dialog = unref(dialogRef)!;
+
+        if (isOpen && !dialog.open) {
+            dialog.showModal();
+            emit('open');
+
+            window.addEventListener('scroll', reposition, {passive: true});
+            onCleanup(() => window.removeEventListener('scroll', reposition));
+        } else if (!isOpen && dialog.open) {
+            dialog.close();
+            emit('close');
+        }
+    });
+
     onUnmounted(() => {
         const pane = unrefTemplateElement(paneRef);
 
@@ -261,21 +276,6 @@
 
         close();
     }
-
-    watch(isOpen, (isOpen, _, onCleanup) => {
-        const dialog = unref(dialogRef)!;
-
-        if (isOpen && !dialog.open) {
-            dialog.showModal();
-            emit('open');
-
-            window.addEventListener('scroll', reposition, {passive: true});
-            onCleanup(() => window.removeEventListener('scroll', reposition));
-        } else if (!isOpen && dialog.open) {
-            dialog.close();
-            emit('close');
-        }
-    });
 
     provide(FluxFlyoutInjectionKey, {
         isClosing,

--- a/packages/components/src/component/FluxFocalPointEditor.vue
+++ b/packages/components/src/component/FluxFocalPointEditor.vue
@@ -86,15 +86,29 @@
 
     const editorRef = useTemplateRef('editor');
     const imageRef = useTemplateRef('image');
-    const translate = useTranslate();
 
     const aspectRatio = ref(1);
     const dragging = ref<[number, number] | null>(null);
     const isPreviewing = ref(false);
     const pointerId = ref<number | null>(null);
 
+    const translate = useTranslate();
+
     const focalPointX = computed(() => unref(dragging) ? unref(dragging)![0] : unref(modelValue)[0]);
     const focalPointY = computed(() => unref(dragging) ? unref(dragging)![1] : unref(modelValue)[1]);
+
+    watch(() => src, async () => {
+        isPreviewing.value = false;
+        aspectRatio.value = 1;
+
+        await nextTick();
+
+        const image = unref(imageRef);
+
+        if (image?.complete) {
+            updateAspectRatio();
+        }
+    });
 
     onMounted(() => {
         window.addEventListener('pointerup', onPointerUp, {passive: true});
@@ -221,17 +235,4 @@
     function onShowPreviewClicked(): void {
         isPreviewing.value = !isPreviewing.value;
     }
-
-    watch(() => src, async () => {
-        isPreviewing.value = false;
-        aspectRatio.value = 1;
-
-        await nextTick();
-
-        const image = unref(imageRef);
-
-        if (image?.complete) {
-            updateAspectRatio();
-        }
-    });
 </script>

--- a/packages/components/src/component/FluxFormCheckbox.vue
+++ b/packages/components/src/component/FluxFormCheckbox.vue
@@ -80,23 +80,31 @@
         readonly value?: FluxFormCheckboxGroupValue;
     }>();
 
+    const inputRef = useTemplateRef('input');
+
     const group = useFormCheckboxGroupInjection();
     const itemControl = inject(FluxItemControlInjectionKey, null);
-    const inputRef = useTemplateRef('input');
     const {id, describedBy} = useFormFieldInjection();
-
-    const isBareControl = computed(() => itemControl?.isControl.value ?? false);
+    const disabled = useDisabled(toRef(() => componentDisabled || (group?.disabled.value ?? false)));
 
     itemControl?.register(id);
 
+    const isBareControl = computed(() => itemControl?.isControl.value ?? false);
     const isGrouped = computed(() => group !== null && value !== undefined);
-
-    const disabled = useDisabled(toRef(() => componentDisabled || (group?.disabled.value ?? false)));
     const isReadonlyResolved = computed(() => isReadonly || (group?.isReadonly.value ?? false));
     const errorResolved = computed(() => unref(isGrouped) ? group?.error.value : error);
-
     const isChecked = computed(() => unref(isGrouped) ? group!.has(value!) : unref(modelValue) === true);
     const isIndeterminate = computed(() => !unref(isGrouped) && unref(modelValue) === null);
+
+    watchEffect(() => {
+        const input = unref(inputRef);
+
+        if (!input) {
+            return;
+        }
+
+        input.indeterminate = unref(isIndeterminate);
+    });
 
     function onChange(): void {
         if (unref(isReadonlyResolved) || unref(disabled)) {
@@ -116,14 +124,4 @@
             evt.preventDefault();
         }
     }
-
-    watchEffect(() => {
-        const input = unref(inputRef);
-
-        if (!input) {
-            return;
-        }
-
-        input.indeterminate = unref(isIndeterminate);
-    });
 </script>

--- a/packages/components/src/component/FluxFormDateTimeInput.vue
+++ b/packages/components/src/component/FluxFormDateTimeInput.vue
@@ -72,13 +72,21 @@
         readonly min?: DateTime;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const flyoutRef = useTemplateRef<{ close(): void; }>('flyout');
+    const disabled = useDisabled(toRef(() => componentDisabled));
 
     const localValue = useDateFlyout(modelValue, flyoutRef, {
         compareKey: value => value?.toISO(),
         transformIn: value => isHourOnly ? value?.startOf('hour') ?? null : value
     });
+
+    watch(() => isHourOnly, () => {
+        if (!isHourOnly) {
+            return;
+        }
+
+        localValue.value = unref(localValue)?.startOf('hour') ?? null;
+    }, {immediate: true});
 
     function setDate(dateTime: DateTime | object | string | number | null): void {
         if (!DateTime.isDateTime(dateTime)) {
@@ -105,12 +113,4 @@
             second: isHourOnly ? 0 : dateTime.second
         });
     }
-
-    watch(() => isHourOnly, () => {
-        if (!isHourOnly) {
-            return;
-        }
-
-        localValue.value = unref(localValue)?.startOf('hour') ?? null;
-    }, {immediate: true});
 </script>

--- a/packages/components/src/component/FluxFormInput.vue
+++ b/packages/components/src/component/FluxFormInput.vue
@@ -129,7 +129,12 @@
         }
 
         if (DateTime.isDateTime(modelValue)) {
-            const iso = modelValue.toISO()!;
+            const iso = modelValue.toISO();
+
+            if (!iso) {
+                localValue.value = null;
+                return;
+            }
 
             switch (type) {
                 case 'date':

--- a/packages/components/src/component/FluxFormInput.vue
+++ b/packages/components/src/component/FluxFormInput.vue
@@ -111,16 +111,87 @@
         readonly type?: FluxInputType;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const inputRef = useTemplateRef<HTMLInputElement>('input');
-    const instance = getCurrentInstance();
-    const translate = useTranslate();
-    const {id, describedBy} = useFormFieldInjection();
-
     const localValue = ref<string | null>(null);
     const nativeType = ref(type);
 
     let activeMask: InputMask<{}> | null = null;
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const instance = getCurrentInstance();
+    const translate = useTranslate();
+    const {id, describedBy} = useFormFieldInjection();
+
+    watch([modelValue, () => type], ([modelValue, type]) => {
+        if (!modelValue && modelValue !== 0) {
+            localValue.value = null;
+            return;
+        }
+
+        if (DateTime.isDateTime(modelValue)) {
+            const iso = modelValue.toISO()!;
+
+            switch (type) {
+                case 'date':
+                    localValue.value = iso.substring(0, 10);
+                    break;
+
+                case 'datetime-local':
+                    localValue.value = iso.substring(0, 16);
+                    break;
+
+                case 'time':
+                    localValue.value = iso.substring(11, 16);
+                    break;
+
+                default:
+                    localValue.value = iso;
+                    break;
+            }
+
+            return;
+        }
+
+        localValue.value = modelValue.toString();
+    }, {immediate: true});
+
+    watch([inputRef, () => pattern], ([input, pattern], __, onCleanup) => {
+        if (!input || !pattern) {
+            return;
+        }
+
+        const mask = inputMask[pattern](input);
+        activeMask = mask;
+
+        const value = unref(localValue);
+
+        if (value) {
+            mask.value = value;
+            localValue.value = mask.value;
+            modelValue.value = mask.value;
+        }
+
+        mask.on('accept', () => {
+            localValue.value = mask.value;
+            modelValue.value = mask.value;
+        });
+
+        onCleanup(() => {
+            mask.destroy();
+
+            if (activeMask === mask) {
+                activeMask = null;
+            }
+        });
+    }, {immediate: true});
+
+    watch(localValue, value => {
+        if (activeMask && activeMask.value !== (value ?? '')) {
+            activeMask.value = value ?? '';
+        }
+    });
+
+    watch(() => type, type => nativeType.value = type);
 
     function blur(): void {
         unrefTemplateElement(inputRef)?.blur();
@@ -217,77 +288,6 @@
             }
         }
     }
-
-    watch([modelValue, () => type], ([modelValue, type]) => {
-        if (!modelValue && modelValue !== 0) {
-            localValue.value = null;
-            return;
-        }
-
-        if (DateTime.isDateTime(modelValue)) {
-            const iso = modelValue.toISO()!;
-
-            switch (type) {
-                case 'date':
-                    localValue.value = iso.substring(0, 10);
-                    break;
-
-                case 'datetime-local':
-                    localValue.value = iso.substring(0, 16);
-                    break;
-
-                case 'time':
-                    localValue.value = iso.substring(11, 16);
-                    break;
-
-                default:
-                    localValue.value = iso;
-                    break;
-            }
-
-            return;
-        }
-
-        localValue.value = modelValue.toString();
-    }, {immediate: true});
-
-    watch([inputRef, () => pattern], ([input, pattern], __, onCleanup) => {
-        if (!input || !pattern) {
-            return;
-        }
-
-        const mask = inputMask[pattern](input);
-        activeMask = mask;
-
-        const value = unref(localValue);
-
-        if (value) {
-            mask.value = value;
-            localValue.value = mask.value;
-            modelValue.value = mask.value;
-        }
-
-        mask.on('accept', () => {
-            localValue.value = mask.value;
-            modelValue.value = mask.value;
-        });
-
-        onCleanup(() => {
-            mask.destroy();
-
-            if (activeMask === mask) {
-                activeMask = null;
-            }
-        });
-    }, {immediate: true});
-
-    watch(localValue, value => {
-        if (activeMask && activeMask.value !== (value ?? '')) {
-            activeMask.value = value ?? '';
-        }
-    });
-
-    watch(() => type, type => nativeType.value = type);
 
     defineExpose({
         blur,

--- a/packages/components/src/component/FluxFormNumberInput.vue
+++ b/packages/components/src/component/FluxFormNumberInput.vue
@@ -90,8 +90,8 @@
         readonly step?: number;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const inputRef = useTemplateRef<HTMLInputElement>('input');
+    const disabled = useDisabled(toRef(() => componentDisabled));
     const {id, describedBy} = useFormFieldInjection();
 
     const atMax = computed(() => max !== undefined && modelValue.value !== null && modelValue.value >= max);

--- a/packages/components/src/component/FluxFormRangeSlider.vue
+++ b/packages/components/src/component/FluxFormRangeSlider.vue
@@ -64,7 +64,7 @@
         minDistance = 0,
         step = 1
     } = defineProps<Pick<FluxFormInputBaseProps, 'disabled' | 'error' | 'isLoading' | 'isReadonly' | 'name'> & {
-        formatter?(value: number, decimals?: number): string;
+        readonly formatter?: (value: number, decimals?: number) => string;
 
         readonly isTicksVisible?: boolean;
         readonly isTooltipDisabled?: boolean;
@@ -74,14 +74,15 @@
         readonly step?: number;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const lowerThumbRef = useTemplateRef('lowerThumb');
     const upperThumbRef = useTemplateRef('upperThumb');
-    const translate = useTranslate();
 
     const isDraggingLower = ref(false);
     const isDraggingUpper = ref(false);
     const tooltipId = ref<number | null>(null);
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const translate = useTranslate();
 
     const span = computed(() => max - min);
     const isRangeValid = computed(() => unref(span) > 0);
@@ -92,6 +93,28 @@
     const percentageUpper = computed(() => unref(isRangeValid) ? (unref(modelValue)[1] - min) / unref(span) : 0);
 
     const tooltipContent = computed(() => formatter(modelValue.value[isDraggingLower.value ? 0 : 1], unref(decimals)));
+
+    watch(([isDraggingLower, isDraggingUpper]), ([isDraggingLower, isDraggingUpper]) => {
+        const is = isDraggingLower || isDraggingUpper;
+
+        if (is && !tooltipId.value && !isTooltipDisabled) {
+            tooltipId.value = addTooltip({
+                content: unref(tooltipContent),
+                direction: 'vertical',
+                origin: unref(isDraggingLower ? lowerThumbRef : upperThumbRef)?.$el
+            });
+        } else if (!is && tooltipId.value) {
+            removeTooltip(tooltipId.value);
+            tooltipId.value = null;
+        }
+    });
+
+    onUnmounted(() => {
+        if (tooltipId.value) {
+            removeTooltip(tooltipId.value);
+            tooltipId.value = null;
+        }
+    });
 
     function snap(value: number): number {
         const stepped = step > 0 ? roundStep(value, step) : value;
@@ -176,26 +199,4 @@
 
         modelValue.value = [snap(lower), snap(upper)];
     }
-
-    watch(([isDraggingLower, isDraggingUpper]), ([isDraggingLower, isDraggingUpper]) => {
-        const is = isDraggingLower || isDraggingUpper;
-
-        if (is && !tooltipId.value && !isTooltipDisabled) {
-            tooltipId.value = addTooltip({
-                content: unref(tooltipContent),
-                direction: 'vertical',
-                origin: unref(isDraggingLower ? lowerThumbRef : upperThumbRef)?.$el
-            });
-        } else if (!is && tooltipId.value) {
-            removeTooltip(tooltipId.value);
-            tooltipId.value = null;
-        }
-    });
-
-    onUnmounted(() => {
-        if (tooltipId.value) {
-            removeTooltip(tooltipId.value);
-            tooltipId.value = null;
-        }
-    });
 </script>

--- a/packages/components/src/component/FluxFormRangeSlider.vue
+++ b/packages/components/src/component/FluxFormRangeSlider.vue
@@ -94,14 +94,14 @@
 
     const tooltipContent = computed(() => formatter(modelValue.value[isDraggingLower.value ? 0 : 1], unref(decimals)));
 
-    watch(([isDraggingLower, isDraggingUpper]), ([isDraggingLower, isDraggingUpper]) => {
-        const is = isDraggingLower || isDraggingUpper;
+    watch([isDraggingLower, isDraggingUpper], ([lower, upper]) => {
+        const is = lower || upper;
 
         if (is && !tooltipId.value && !isTooltipDisabled) {
             tooltipId.value = addTooltip({
                 content: unref(tooltipContent),
                 direction: 'vertical',
-                origin: unref(isDraggingLower ? lowerThumbRef : upperThumbRef)?.$el
+                origin: unref(lower ? lowerThumbRef : upperThumbRef)?.$el
             });
         } else if (!is && tooltipId.value) {
             removeTooltip(tooltipId.value);

--- a/packages/components/src/component/FluxFormRating.vue
+++ b/packages/components/src/component/FluxFormRating.vue
@@ -66,6 +66,10 @@
     import FluxIcon from './FluxIcon.vue';
     import $style from '~flux/components/css/component/FormRating.module.scss';
 
+    const emit = defineEmits<{
+        change: [number | null];
+    }>();
+
     const modelValue = defineModel<number | null>({
         default: null
     });
@@ -85,15 +89,11 @@
         readonly size?: number;
     }>();
 
-    const emit = defineEmits<{
-        change: [number | null];
-    }>();
+    const rootRef = useTemplateRef('root');
+    const hoverValue = ref<number | null>(null);
 
     const disabled = useDisabled(toRef(() => componentDisabled));
-    const rootRef = useTemplateRef('root');
     const {id, describedBy} = useFormFieldInjection();
-
-    const hoverValue = ref<number | null>(null);
 
     const isInteractive = computed(() => !disabled.value && !isReadonly);
     const displayValue = computed(() => hoverValue.value ?? modelValue.value ?? 0);

--- a/packages/components/src/component/FluxFormSelectAsync.vue
+++ b/packages/components/src/component/FluxFormSelectAsync.vue
@@ -49,16 +49,20 @@
         disabled: componentDisabled,
         isMultiple
     } = defineProps<Pick<FluxFormInputBaseProps, 'autoFocus' | 'disabled' | 'error' | 'isCondensed' | 'isLoading' | 'isReadonly' | 'isSecondary' | 'name' | 'placeholder'> & {
-        fetchOptions(ids: FluxFormSelectValueSingle[]): Promise<FluxFormSelectEntry[]>;
-        fetchRelevant(): Promise<FluxFormSelectEntry[]>;
-        fetchSearch(searchQuery: string): Promise<FluxFormSelectEntry[]>;
+        readonly fetchOptions: (ids: FluxFormSelectValueSingle[]) => Promise<FluxFormSelectEntry[]>;
+        readonly fetchRelevant: () => Promise<FluxFormSelectEntry[]>;
+        readonly fetchSearch: (searchQuery: string) => Promise<FluxFormSelectEntry[]>;
 
         readonly isMultiple?: boolean;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const selectedOptions = ref<FluxFormSelectEntry[]>([]);
     const visibleOptions = ref<FluxFormSelectEntry[]>([]);
+
+    let selectedGeneration = 0;
+    let visibleGeneration = 0;
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
 
     const options = computed(() => {
         const options: FluxFormSelectEntry[] = [];
@@ -86,38 +90,10 @@
     const {groups, selected, values} = useFormSelect(modelValue, isMultiple, options);
     const {isLoading: isFetchingLoading, loaded} = useLoaded();
     const debouncedModelSearch = useDebouncedRef(modelSearch, 300) as unknown as Ref<string>;
+
     const fetchOptions = computed(() => loaded(fetchOptionsProp));
     const fetchRelevant = computed(() => loaded(fetchRelevantProp));
     const fetchSearch = computed(() => loaded(fetchSearchProp));
-
-    let selectedGeneration = 0;
-    let visibleGeneration = 0;
-
-    function onDeselect(id: string | number | null): void {
-        if (isMultiple) {
-            modelValue.value = unref(values).filter(v => v !== id);
-        }
-    }
-
-    async function onOpen(): Promise<void> {
-        const generation = ++visibleGeneration;
-        const search = unref(modelSearch).trim();
-        const options = search.length > 0
-            ? await unref(fetchSearch)(search)
-            : await unref(fetchRelevant)();
-
-        if (generation === visibleGeneration) {
-            visibleOptions.value = options;
-        }
-    }
-
-    function onSelect(id: string | number | null): void {
-        if (isMultiple) {
-            modelValue.value = [...unref(values), id];
-        } else {
-            modelValue.value = id;
-        }
-    }
 
     watch(values, async values => {
         const definedValues = values.filter(value => value !== null && value !== undefined);
@@ -146,4 +122,30 @@
             visibleOptions.value = options;
         }
     });
+
+    function onDeselect(id: string | number | null): void {
+        if (isMultiple) {
+            modelValue.value = unref(values).filter(v => v !== id);
+        }
+    }
+
+    async function onOpen(): Promise<void> {
+        const generation = ++visibleGeneration;
+        const search = unref(modelSearch).trim();
+        const options = search.length > 0
+            ? await unref(fetchSearch)(search)
+            : await unref(fetchRelevant)();
+
+        if (generation === visibleGeneration) {
+            visibleOptions.value = options;
+        }
+    }
+
+    function onSelect(id: string | number | null): void {
+        if (isMultiple) {
+            modelValue.value = [...unref(values), id];
+        } else {
+            modelValue.value = id;
+        }
+    }
 </script>

--- a/packages/components/src/component/FluxFormTagsInput.vue
+++ b/packages/components/src/component/FluxFormTagsInput.vue
@@ -82,6 +82,11 @@
     import FluxTag from './FluxTag.vue';
     import $style from '~flux/components/css/component/Form.module.scss';
 
+    const emit = defineEmits<{
+        add: [string];
+        remove: [string];
+    }>();
+
     const modelValue = defineModel<string[]>({
         default: () => []
     });
@@ -108,21 +113,20 @@
         readonly validate?: (value: string) => boolean;
     }>();
 
-    const emit = defineEmits<{
-        add: [string];
-        remove: [string];
-    }>();
-
-    const disabled = useDisabled(toRef(() => componentDisabled));
-    const {id, describedBy} = useFormFieldInjection();
-    const popupId = useId();
-
     const anchorRef = useTemplateRef<ComponentPublicInstance>('anchor');
     const popupRef = useTemplateRef<ComponentPublicInstance>('popup');
     const inputElementRef = useTemplateRef<HTMLInputElement>('input');
 
     const isOpen = ref(false);
     const highlightedIndex = ref(-1);
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const {id, describedBy} = useFormFieldInjection();
+    const popupId = useId();
+
+    if (typeof window !== 'undefined') {
+        useClickOutside([anchorRef, popupRef], isOpen, () => isOpen.value = false);
+    }
 
     const isMaxReached = computed(() => max !== undefined && modelValue.value.length >= max);
     const filteredSuggestions = computed(() => {
@@ -261,9 +265,5 @@
 
         evt.preventDefault();
         parts.forEach(addTag);
-    }
-
-    if (typeof window !== 'undefined') {
-        useClickOutside([anchorRef, popupRef], isOpen, () => isOpen.value = false);
     }
 </script>

--- a/packages/components/src/component/FluxFormTextArea.vue
+++ b/packages/components/src/component/FluxFormTextArea.vue
@@ -56,8 +56,8 @@
         readonly rows?: number;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const inputRef = useTemplateRef<HTMLTextAreaElement>('input');
+    const disabled = useDisabled(toRef(() => componentDisabled));
     const {id, describedBy} = useFormFieldInjection();
 
     function blur(): void {

--- a/packages/components/src/component/FluxFormTreeViewSelect.vue
+++ b/packages/components/src/component/FluxFormTreeViewSelect.vue
@@ -160,15 +160,6 @@
         readonly options: FluxFormTreeViewSelectOption[];
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
-    const {id, describedBy} = useFormFieldInjection();
-    const translate = useTranslate();
-    const listId = useId();
-
-    function optionId(index: number): string {
-        return `${listId}-option-${index}`;
-    }
-
     const anchorRef = useTemplateRef<ComponentPublicInstance>('anchor');
     const anchorPopupRef = useTemplateRef<ComponentPublicInstance>('anchorPopup');
     const nodeElementRefs = useTemplateRef<HTMLDivElement[]>('nodeElements');
@@ -176,6 +167,11 @@
 
     const expandedIds = ref(new Set<string | number>());
     const searchQuery = ref('');
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const {id, describedBy} = useFormFieldInjection();
+    const translate = useTranslate();
+    const listId = useId();
 
     const focusElement = computed(() => unrefTemplateElement(searchInputRef) ?? unrefTemplateElement(anchorRef));
 
@@ -223,6 +219,34 @@
         nodeElementRefs,
         visibleNodes
     });
+
+    watch(isPopupOpen, isOpen => {
+        if (!isOpen) {
+            searchQuery.value = '';
+            highlightedIndex.value = INITIAL_HIGHLIGHTED_INDEX;
+            return;
+        }
+
+        autoExpandSelected();
+
+        nextTick(() => {
+            const ids = unref(selectedIds);
+            if (ids.size > 0) {
+                const firstSelectedIndex = unref(visibleNodes).findIndex(n => ids.has(n.id));
+                if (firstSelectedIndex >= 0) {
+                    highlightedIndex.value = firstSelectedIndex;
+                }
+            }
+        });
+    });
+
+    watch(searchQuery, () => {
+        highlightedIndex.value = INITIAL_HIGHLIGHTED_INDEX;
+    });
+
+    function optionId(index: number): string {
+        return `${listId}-option-${index}`;
+    }
 
     function select(nodeId: string | number): void {
         if (unref(isMultiple)) {
@@ -297,30 +321,6 @@
 
         onKeyNavigate(evt, onNodeClick);
     }
-
-    watch(isPopupOpen, isOpen => {
-        if (!isOpen) {
-            searchQuery.value = '';
-            highlightedIndex.value = INITIAL_HIGHLIGHTED_INDEX;
-            return;
-        }
-
-        autoExpandSelected();
-
-        nextTick(() => {
-            const ids = unref(selectedIds);
-            if (ids.size > 0) {
-                const firstSelectedIndex = unref(visibleNodes).findIndex(n => ids.has(n.id));
-                if (firstSelectedIndex >= 0) {
-                    highlightedIndex.value = firstSelectedIndex;
-                }
-            }
-        });
-    });
-
-    watch(searchQuery, () => {
-        highlightedIndex.value = INITIAL_HIGHLIGHTED_INDEX;
-    });
 
     function autoExpandSelected(): void {
         const ids = unref(selectedIds);

--- a/packages/components/src/component/FluxIcon.vue
+++ b/packages/components/src/component/FluxIcon.vue
@@ -21,7 +21,8 @@
         :aria-label="ariaLabel"
         @click="onClick">
         <path
-            v-for="path in definition.paths"
+            v-for="(path, index) in definition.paths"
+            :key="index"
             :d="path"
             fill="currentColor"/>
     </svg>
@@ -75,5 +76,7 @@
         };
     });
 
-    const onClick = (evt: MouseEvent) => emit('click', evt);
+    function onClick(evt: MouseEvent): void {
+        emit('click', evt);
+    }
 </script>

--- a/packages/components/src/component/FluxInlineEdit.vue
+++ b/packages/components/src/component/FluxInlineEdit.vue
@@ -74,6 +74,12 @@
     import FluxSecondaryButton from './FluxSecondaryButton.vue';
     import $style from '~flux/components/css/component/InlineEdit.module.scss';
 
+    const emit = defineEmits<{
+        cancel: [];
+        edit: [];
+        save: [string];
+    }>();
+
     const modelValue = defineModel<string>({
         default: ''
     });
@@ -92,18 +98,11 @@
         readonly saveOnBlur?: boolean;
     }>();
 
-    const emit = defineEmits<{
-        cancel: [];
-        edit: [];
-        save: [string];
-    }>();
-
     defineSlots<{
         actions?(props: {save(): void; cancel(): void}): VNode[];
         default?(props: {value: string; edit(): void}): VNode[];
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const rootRef = useTemplateRef<HTMLElement>('root');
     const displayRef = useTemplateRef<HTMLElement>('display');
     const fieldRef = useTemplateRef<{focus(): void}>('field');
@@ -111,6 +110,8 @@
     const isEditing = ref(false);
     const isCancelling = ref(false);
     const draft = ref('');
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
 
     const isInteractive = computed(() => !disabled.value && !isReadonly);
 

--- a/packages/components/src/component/FluxKanban.vue
+++ b/packages/components/src/component/FluxKanban.vue
@@ -24,6 +24,11 @@
     import { FluxDisabledInjectionKey, FluxKanbanInjectionKey } from '~flux/components/data';
     import $style from '~flux/components/css/component/Kanban.module.scss';
 
+    const emit = defineEmits<{
+        move: [FluxKanbanMoveEvent];
+        moveColumn: [FluxKanbanMoveColumnEvent];
+    }>();
+
     const {
         canMove,
         disabled = false,
@@ -32,11 +37,6 @@
         readonly canMove?: (event: FluxKanbanMoveEvent) => boolean;
         readonly disabled?: boolean;
         readonly reorderableColumns?: boolean;
-    }>();
-
-    const emit = defineEmits<{
-        move: [FluxKanbanMoveEvent];
-        moveColumn: [FluxKanbanMoveColumnEvent];
     }>();
 
     defineSlots<{
@@ -66,9 +66,11 @@
 
     const isDragging = computed(() => kanban.dragState.value !== null || kanban.columnDragState.value !== null);
 
-    function onPointerMove(evt: DragEvent | PointerEvent): void {
-        kanban.onPointerMove(evt.clientX, evt.clientY);
-    }
+    watch(() => disabled, value => {
+        if (value) {
+            kanban.cancelAll();
+        }
+    });
 
     onMounted(() => {
         kanban.setBoardElement(root.value);
@@ -82,11 +84,9 @@
         window.removeEventListener('dragend', kanban.cancelAll);
     });
 
-    watch(() => disabled, value => {
-        if (value) {
-            kanban.cancelAll();
-        }
-    });
+    function onPointerMove(evt: DragEvent | PointerEvent): void {
+        kanban.onPointerMove(evt.clientX, evt.clientY);
+    }
 
     provide(FluxKanbanInjectionKey, kanban);
     provide(FluxDisabledInjectionKey, disabledRef);

--- a/packages/components/src/component/FluxKanbanColumn.vue
+++ b/packages/components/src/component/FluxKanbanColumn.vue
@@ -105,10 +105,10 @@
         footer?(): any;
     }>();
 
-    const kanban = useKanbanInjection();
     const root = useTemplateRef('root');
     const header = useTemplateRef('header');
     const body = useTemplateRef('body');
+    const kanban = useKanbanInjection();
     const slots = useSlots();
 
     const disabledState = useDisabled(toRef(() => disabled));
@@ -166,6 +166,39 @@
     });
 
     const hasFooter = computed(() => !!slots.footer);
+
+    watch(() => columnId, (newId, oldId) => {
+        if (oldId !== undefined) {
+            kanban.setColumnBodyElement(oldId, null);
+        }
+
+        if (root.value) {
+            kanban.unregisterColumn(root.value);
+            kanban.registerColumn(root.value, newId);
+        }
+
+        if (body.value) {
+            kanban.setColumnBodyElement(newId, body.value);
+        }
+    });
+
+    onMounted(() => {
+        if (root.value) {
+            kanban.registerColumn(root.value, columnId);
+        }
+
+        if (body.value) {
+            kanban.setColumnBodyElement(columnId, body.value);
+        }
+    });
+
+    onBeforeUnmount(() => {
+        if (root.value) {
+            kanban.unregisterColumn(root.value);
+        }
+
+        kanban.setColumnBodyElement(columnId, null);
+    });
 
     function onDragEnter(): void {
         kanban.enterColumn(columnId);
@@ -309,37 +342,4 @@
             }
         }
     }
-
-    onMounted(() => {
-        if (root.value) {
-            kanban.registerColumn(root.value, columnId);
-        }
-
-        if (body.value) {
-            kanban.setColumnBodyElement(columnId, body.value);
-        }
-    });
-
-    onBeforeUnmount(() => {
-        if (root.value) {
-            kanban.unregisterColumn(root.value);
-        }
-
-        kanban.setColumnBodyElement(columnId, null);
-    });
-
-    watch(() => columnId, (newId, oldId) => {
-        if (oldId !== undefined) {
-            kanban.setColumnBodyElement(oldId, null);
-        }
-
-        if (root.value) {
-            kanban.unregisterColumn(root.value);
-            kanban.registerColumn(root.value, newId);
-        }
-
-        if (body.value) {
-            kanban.setColumnBodyElement(newId, body.value);
-        }
-    });
 </script>

--- a/packages/components/src/component/FluxKanbanItem.vue
+++ b/packages/components/src/component/FluxKanbanItem.vue
@@ -44,14 +44,9 @@
         default?(): any;
     }>();
 
-    const kanban = useKanbanInjection();
     const root = useTemplateRef('root');
+    const kanban = useKanbanInjection();
     const disabledState = useDisabled(toRef(() => disabled));
-
-    const isDragging = computed(() => {
-        const state = unref(kanban.dragState);
-        return state?.itemId === itemId && state?.mode === 'pointer';
-    });
 
     const {isGrabbed, handleKeyDown, release} = useKeyboardGrab<true>({
         isDraggable: computed(() => !unref(disabledState)),
@@ -75,6 +70,18 @@
         }
     });
 
+    const isDragging = computed(() => {
+        const state = unref(kanban.dragState);
+        return state?.itemId === itemId && state?.mode === 'pointer';
+    });
+
+    watch(() => itemId, (newId, oldId) => {
+        if (root.value && oldId !== undefined) {
+            kanban.unregisterItem(root.value);
+            kanban.registerItem(root.value, newId);
+        }
+    });
+
     onMounted(() => {
         if (root.value) {
             kanban.registerItem(root.value, itemId);
@@ -88,13 +95,6 @@
     onBeforeUnmount(() => {
         if (root.value) {
             kanban.unregisterItem(root.value);
-        }
-    });
-
-    watch(() => itemId, (newId, oldId) => {
-        if (root.value && oldId !== undefined) {
-            kanban.unregisterItem(root.value);
-            kanban.registerItem(root.value, newId);
         }
     });
 

--- a/packages/components/src/component/FluxMenuCollapsible.vue
+++ b/packages/components/src/component/FluxMenuCollapsible.vue
@@ -87,6 +87,26 @@
     const instance = getCurrentInstance();
     const route = computed<RouteLike | undefined>(() => (instance?.proxy as RouteAwareInstance | null)?.$route);
 
+    watch(route, currentRoute => {
+        if (!currentRoute) {
+            return;
+        }
+
+        const vnodes = flattenVNodeTree(slots.default?.() ?? []);
+
+        for (const vnode of vnodes) {
+            const childTo = vnode.props?.to;
+            const childHref = vnode.props?.href;
+
+            if (matchesRoute(childTo, currentRoute) || matchesRoute(childHref, currentRoute)) {
+                open();
+                return;
+            }
+        }
+    }, {
+        immediate: true
+    });
+
     function open(): void {
         if (isOpen.value) {
             return;
@@ -144,26 +164,6 @@
 
         return false;
     }
-
-    watch(route, currentRoute => {
-        if (!currentRoute) {
-            return;
-        }
-
-        const vnodes = flattenVNodeTree(slots.default?.() ?? []);
-
-        for (const vnode of vnodes) {
-            const childTo = vnode.props?.to;
-            const childHref = vnode.props?.href;
-
-            if (matchesRoute(childTo, currentRoute) || matchesRoute(childHref, currentRoute)) {
-                open();
-                return;
-            }
-        }
-    }, {
-        immediate: true
-    });
 
     defineExpose({
         isOpen,

--- a/packages/components/src/component/FluxMenuItem.vue
+++ b/packages/components/src/component/FluxMenuItem.vue
@@ -78,11 +78,6 @@
 
     const emit = defineEmits<FluxButtonEmits>();
 
-    const slots = defineSlots<{
-        after(): VNode[];
-        before(): VNode[];
-    }>();
-
     const {
         isPersistent,
         type = 'button'
@@ -99,6 +94,11 @@
         readonly isPersistent?: boolean;
         readonly isSelectable?: boolean;
         readonly isSelected?: boolean;
+    }>();
+
+    const slots = defineSlots<{
+        after(): VNode[];
+        before(): VNode[];
     }>();
 
     const persistentPolicy = inject(FluxMenuPersistentInjectionKey, null);

--- a/packages/components/src/component/FluxMenuOptions.vue
+++ b/packages/components/src/component/FluxMenuOptions.vue
@@ -1,6 +1,6 @@
 <template>
     <FluxMenuGroup :is-horizontal="isHorizontal">
-        <template v-for="item in items">
+        <template v-for="(item, index) in items" :key="identityOf(item, index)">
             <component :is="item"/>
         </template>
     </FluxMenuGroup>
@@ -30,15 +30,6 @@
         default(): VNode[];
     }>();
 
-    // Each item is identified by its vnode key when it is a string or number, falling back to its
-    // position. Keying the items makes the selection survive conditional or reordered items — without a
-    // usable key the index is the only stable handle, so it keeps working for simple static lists.
-    function identityOf(item: VNode, index: number): string | number {
-        const key = item.key;
-
-        return typeof key === 'string' || typeof key === 'number' ? key : index;
-    }
-
     // Options menus stay open while selecting by default (isPersistent defaults to true). The behaviour
     // is injected directly as a prop on each item rather than via the FluxMenuPersistentInjectionKey
     // provider, because the cloned option vnodes do not resolve a provide from this component.
@@ -54,4 +45,13 @@
                 onClick: () => modelValue.value = identity
             });
         }));
+
+    // Each item is identified by its vnode key when it is a string or number, falling back to its
+    // position. Keying the items makes the selection survive conditional or reordered items — without a
+    // usable key the index is the only stable handle, so it keeps working for simple static lists.
+    function identityOf(item: VNode, index: number): string | number {
+        const key = item.key;
+
+        return typeof key === 'string' || typeof key === 'number' ? key : index;
+    }
 </script>

--- a/packages/components/src/component/FluxOverflowBar.vue
+++ b/packages/components/src/component/FluxOverflowBar.vue
@@ -11,7 +11,7 @@
         :style="{
             gap: `${gap}px`
         }">
-        <template v-for="item of items.slice(0, visibleItems)">
+        <template v-for="(item, index) of items.slice(0, visibleItems)" :key="index">
             <FluxDynamicView :vnode="item"/>
         </template>
 

--- a/packages/components/src/component/FluxPagination.vue
+++ b/packages/components/src/component/FluxPagination.vue
@@ -13,7 +13,8 @@
 
         <template
             v-if="!isCompact"
-            v-for="p of visiblePages">
+            v-for="(p, index) of visiblePages"
+            :key="index">
             <span
                 v-if="p === 'dots'"
                 :class="$style.paginationDots"

--- a/packages/components/src/component/FluxPagination.vue
+++ b/packages/components/src/component/FluxPagination.vue
@@ -11,26 +11,27 @@
             :aria-label="translate('flux.previous')"
             @click="previous"/>
 
-        <template
-            v-if="!isCompact"
-            v-for="(p, index) of visiblePages"
-            :key="index">
-            <span
-                v-if="p === 'dots'"
-                :class="$style.paginationDots"
-                aria-hidden="true">…</span>
+        <template v-if="!isCompact">
+            <template
+                v-for="(p, index) of visiblePages"
+                :key="index">
+                <span
+                    v-if="p === 'dots'"
+                    :class="$style.paginationDots"
+                    aria-hidden="true">…</span>
 
-            <FluxPaginationButton
-                v-else-if="p === page"
-                is-current
-                :label="`${p}`"
-                aria-current="page"/>
+                <FluxPaginationButton
+                    v-else-if="p === page"
+                    is-current
+                    :label="`${p}`"
+                    aria-current="page"/>
 
-            <FluxPaginationButton
-                v-else
-                :aria-label="translate('flux.goToPage', {page: p})"
-                :label="`${p}`"
-                @click="navigate(p)"/>
+                <FluxPaginationButton
+                    v-else
+                    :aria-label="translate('flux.goToPage', {page: p})"
+                    :label="`${p}`"
+                    @click="navigate(p)"/>
+            </template>
         </template>
 
         <template v-else>

--- a/packages/components/src/component/FluxPaginationBar.vue
+++ b/packages/components/src/component/FluxPaginationBar.vue
@@ -12,13 +12,7 @@
 
         <div :class="$style.paginationBarLimit">
             <span :class="$style.paginationBarLimitDisplayingOf">
-                {{
-                    translate('flux.displayingOf', {
-                        from: total === 0 ? 0 : (page - 1) * perPage + 1,
-                        to: Math.min(total, page * perPage),
-                        total: total
-                    })
-                }}
+                {{ translate('flux.displayingOf', displayRange) }}
             </span>
 
             <FluxFormSelect
@@ -47,7 +41,9 @@
 
     const {
         limits = [5, 10, 25, 50, 100],
-        perPage
+        page,
+        perPage,
+        total
     } = defineProps<{
         readonly limits?: number[];
         readonly page: number;
@@ -63,6 +59,12 @@
         label: translate('flux.showN', {n}),
         value: n
     })));
+
+    const displayRange = computed(() => ({
+        from: total === 0 ? 0 : (page - 1) * perPage + 1,
+        to: Math.min(total, page * perPage),
+        total
+    }));
 
     watch(limit, value => {
         if (value === perPage) {

--- a/packages/components/src/component/FluxQuantitySelector.vue
+++ b/packages/components/src/component/FluxQuantitySelector.vue
@@ -67,11 +67,33 @@
         readonly step?: number;
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const inputRef = useTemplateRef('input');
+    const width = ref(0);
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
     const translate = useTranslate();
 
-    const width = ref(0);
+    watch(modelValue, value => {
+        if (typeof value !== 'number' || isNaN(value)) {
+            modelValue.value = min;
+            return;
+        }
+
+        const clamped = clamp(value);
+
+        if (clamped !== value) {
+            modelValue.value = clamped;
+            return;
+        }
+
+        sizeToContent();
+    }, {immediate: true});
+
+    // The immediate watch above runs during setup, before the <input> is mounted, so its sizeToContent()
+    // call bails on a null ref. Size once more after mount so the input has the correct width on pageload.
+    onMounted(() => {
+        sizeToContent();
+    });
 
     function clamp(value: number): number {
         return Math.min(max, Math.max(min, value));
@@ -127,26 +149,4 @@
             width.value = Math.max(51, input.scrollWidth + 30);
         });
     }
-
-    watch(modelValue, value => {
-        if (typeof value !== 'number' || isNaN(value)) {
-            modelValue.value = min;
-            return;
-        }
-
-        const clamped = clamp(value);
-
-        if (clamped !== value) {
-            modelValue.value = clamped;
-            return;
-        }
-
-        sizeToContent();
-    }, {immediate: true});
-
-    // The immediate watch above runs during setup, before the <input> is mounted, so its sizeToContent()
-    // call bails on a null ref. Size once more after mount so the input has the correct width on pageload.
-    onMounted(() => {
-        sizeToContent();
-    });
 </script>

--- a/packages/components/src/component/FluxSegmentedControl.vue
+++ b/packages/components/src/component/FluxSegmentedControl.vue
@@ -57,12 +57,12 @@
         }
     });
 
-    onMounted(() => updateHighlight());
+    useMutationObserver(controlRef, () => updateHighlight(), {childList: true, subtree: true});
+    useResizeObserver(controlRef, () => updateHighlight());
 
     watch(modelValue, () => updateHighlight(), {flush: 'post'});
 
-    useMutationObserver(controlRef, () => updateHighlight(), {childList: true, subtree: true});
-    useResizeObserver(controlRef, () => updateHighlight());
+    onMounted(() => updateHighlight());
 
     function select(value: FluxSegmentedControlValue): void {
         modelValue.value = value;

--- a/packages/components/src/component/FluxSegmentedControlItem.vue
+++ b/packages/components/src/component/FluxSegmentedControlItem.vue
@@ -43,10 +43,6 @@
         default(): any;
     }>();
 
-    const control = useSegmentedControlInjection();
-    const disabled = useDisabled(toRef(() => componentDisabled));
-    const itemRef = useTemplateRef<HTMLButtonElement>('item');
-
     const sizeClasses = {
         small: $style.isSmall,
         medium: $style.isMedium,
@@ -58,7 +54,11 @@
         large: 18
     };
 
+    const itemRef = useTemplateRef<HTMLButtonElement>('item');
     const isFirstEnabled = ref(false);
+
+    const control = useSegmentedControlInjection();
+    const disabled = useDisabled(toRef(() => componentDisabled));
 
     const isActive = computed(() => control.modelValue.value === value);
     const iconSize = computed(() => iconSizes[unref(control.size)]);

--- a/packages/components/src/component/FluxSnackbar.vue
+++ b/packages/components/src/component/FluxSnackbar.vue
@@ -128,6 +128,32 @@
 
     const hasActions = computed(() => actions && Object.entries(actions).length > 0);
 
+    watchEffect(() => {
+        if (!id.value) {
+            return;
+        }
+
+        updateSnackbar(id.value, buildSpec());
+    });
+
+    watch(() => isRendered, () => {
+        if (isRendered) {
+            if (id.value) {
+                removeSnackbar(id.value);
+            }
+
+            return;
+        }
+
+        id.value = addSnackbar(buildSpec());
+    }, {immediate: true});
+
+    onBeforeUnmount(() => {
+        if (id.value) {
+            removeSnackbar(id.value);
+        }
+    });
+
     function onMouseEnter(): void {
         if (storeId != null) {
             pauseSnackbar(storeId);
@@ -139,12 +165,6 @@
             resumeSnackbar(storeId);
         }
     }
-
-    onBeforeUnmount(() => {
-        if (id.value) {
-            removeSnackbar(id.value);
-        }
-    });
 
     function onAction(actionKey: string): void {
         emit('action', actionKey);
@@ -174,24 +194,4 @@
             onClose
         };
     }
-
-    watchEffect(() => {
-        if (!id.value) {
-            return;
-        }
-
-        updateSnackbar(id.value, buildSpec());
-    });
-
-    watch(() => isRendered, () => {
-        if (isRendered) {
-            if (id.value) {
-                removeSnackbar(id.value);
-            }
-
-            return;
-        }
-
-        id.value = addSnackbar(buildSpec());
-    }, {immediate: true});
 </script>

--- a/packages/components/src/component/FluxSplitButton.vue
+++ b/packages/components/src/component/FluxSplitButton.vue
@@ -38,8 +38,6 @@
     import FluxSecondaryButton from './FluxSecondaryButton.vue';
     import $style from '~flux/components/css/component/Button.module.scss';
 
-    const translate = useTranslate();
-
     const {
         buttonIcon = 'ellipsis-h'
     } = defineProps<{
@@ -67,4 +65,6 @@
             readonly openerHeight: number;
         }): VNode[];
     }>();
+
+    const translate = useTranslate();
 </script>

--- a/packages/components/src/component/FluxStepper.vue
+++ b/packages/components/src/component/FluxStepper.vue
@@ -60,11 +60,11 @@
     const steps = computed(() => unref(children).length);
     const view = computed(() => unref(children)[unref(modelValue)] ?? null);
 
-    function activate(index: number): void {
-        modelValue.value = index;
-    }
-
     watch(modelValue, (newIndex, oldIndex) => {
         isTransitioningBack.value = newIndex < oldIndex;
     });
+
+    function activate(index: number): void {
+        modelValue.value = index;
+    }
 </script>

--- a/packages/components/src/component/FluxTabBarItem.vue
+++ b/packages/components/src/component/FluxTabBarItem.vue
@@ -59,9 +59,13 @@
         readonly to?: FluxTo;
     }>();
 
+    const tabRef = useTemplateRef<ComponentPublicInstance>('tab');
+    const isFirstEnabled = ref(false);
+
+    let registeredElement: Element | null = null;
+
     const disabled = useDisabled(toRef(() => componentDisabled));
     const tabBar = useTabBarInjection();
-    const tabRef = useTemplateRef<ComponentPublicInstance>('tab');
 
     const itemClass = computed(() => {
         if (tabBar.isPills.value) {
@@ -70,8 +74,6 @@
 
         return isActive ? $style.tabBarItemDefaultActive : $style.tabBarItemDefault;
     });
-
-    const isFirstEnabled = ref(false);
 
     const resolvedTabindex = computed(() => {
         if (componentDisabled || unref(disabled)) {
@@ -89,11 +91,33 @@
         return -1;
     });
 
-    let registeredElement: Element | null = null;
-
     const tabListRef = computed(() => (unref(tabRef)?.$el as Element | undefined)?.parentElement ?? null);
 
     useMutationObserver(tabListRef, () => updateFirstEnabled(), {attributeFilter: ['aria-disabled', 'aria-selected'], attributes: true, childList: true, subtree: true});
+
+    watch(() => isActive, () => {
+        if (!isActive) {
+            return;
+        }
+
+        const tab = unref(tabRef);
+
+        if (!tab) {
+            return;
+        }
+
+        const el = tab.$el;
+
+        if (el.parentElement?.offsetWidth === el.parentElement?.scrollWidth) {
+            return;
+        }
+
+        el.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+            inline: 'center'
+        });
+    }, {immediate: true});
 
     onMounted(() => {
         const tab = unref(tabRef);
@@ -150,28 +174,4 @@
     function onMouseLeave(evt: MouseEvent): void {
         emit('mouseleave', evt);
     }
-
-    watch(() => isActive, () => {
-        if (!isActive) {
-            return;
-        }
-
-        const tab = unref(tabRef);
-
-        if (!tab) {
-            return;
-        }
-
-        const el = tab.$el;
-
-        if (el.parentElement?.offsetWidth === el.parentElement?.scrollWidth) {
-            return;
-        }
-
-        el.scrollIntoView({
-            behavior: 'smooth',
-            block: 'nearest',
-            inline: 'center'
-        });
-    }, {immediate: true});
 </script>

--- a/packages/components/src/component/FluxTable.vue
+++ b/packages/components/src/component/FluxTable.vue
@@ -172,6 +172,35 @@
 
     const fillCellCount = computed(() => unref(sortedColumns).length || fallbackColumnCount.value);
 
+    const gridTemplateColumns = computed(() => {
+        const columns = unref(sortedColumns);
+
+        if (columns.length === 0) {
+            return fallbackColumnCount.value > 0 ? `repeat(${fallbackColumnCount.value}, auto)` : 'none';
+        }
+
+        return columns
+            .map(column => {
+                if (column.width !== undefined) {
+                    return `${column.width}px`;
+                }
+
+                if (column.isShrinking) {
+                    return 'auto';
+                }
+
+                if (column.minWidth === undefined && column.maxWidth === undefined) {
+                    return '1fr';
+                }
+
+                const min = column.minWidth !== undefined ? `${column.minWidth}px` : 'auto';
+                const max = column.maxWidth !== undefined ? `${column.maxWidth}px` : '1fr';
+
+                return `minmax(${min}, ${max})`;
+            })
+            .join(' ');
+    });
+
     // The filler and empty rows are their own 1fr row tracks, so the layout
     // engine hands them the remaining height synchronously instead of a
     // measurement pass doing so a frame later. Slot presence is not reactive,
@@ -202,35 +231,6 @@
 
         return rows.length > 0 ? rows.join(' ') : undefined;
     }
-
-    const gridTemplateColumns = computed(() => {
-        const columns = unref(sortedColumns);
-
-        if (columns.length === 0) {
-            return fallbackColumnCount.value > 0 ? `repeat(${fallbackColumnCount.value}, auto)` : 'none';
-        }
-
-        return columns
-            .map(column => {
-                if (column.width !== undefined) {
-                    return `${column.width}px`;
-                }
-
-                if (column.isShrinking) {
-                    return 'auto';
-                }
-
-                if (column.minWidth === undefined && column.maxWidth === undefined) {
-                    return '1fr';
-                }
-
-                const min = column.minWidth !== undefined ? `${column.minWidth}px` : 'auto';
-                const max = column.maxWidth !== undefined ? `${column.maxWidth}px` : '1fr';
-
-                return `minmax(${min}, ${max})`;
-            })
-            .join(' ');
-    });
 
     function registerColumn(element: Readonly<Ref<HTMLElement | null>>, column: Readonly<Ref<FluxTableColumnDef>>): () => void {
         const registration: ColumnRegistration = {column, element};
@@ -418,13 +418,6 @@
         style.borderBottomRightRadius = footHeight.value > 0 ? '0' : '';
     });
 
-    // The columns registered during setup only reach the DOM with the next
-    // template patch, which lands after ancestors' mounted hooks. Write the
-    // template immediately so mounted-time measurements see the real layout.
-    onMounted(() => {
-        unref(base)?.style.setProperty('--flux-table-columns', gridTemplateColumns.value);
-    });
-
     watch(sortedColumns, () => measure());
 
     watch([base, headRef, bodyRef, footRef], ([baseEl, head, bodyEl, foot], _, onCleanup) => {
@@ -454,6 +447,13 @@
 
         onCleanup(() => observer.disconnect());
     }, {immediate: true});
+
+    // The columns registered during setup only reach the DOM with the next
+    // template patch, which lands after ancestors' mounted hooks. Write the
+    // template immediately so mounted-time measurements see the real layout.
+    onMounted(() => {
+        unref(base)?.style.setProperty('--flux-table-columns', gridTemplateColumns.value);
+    });
 
     provide(FluxTableInjectionKey, {
         activeRow,

--- a/packages/components/src/component/FluxTableCell.vue
+++ b/packages/components/src/component/FluxTableCell.vue
@@ -82,12 +82,6 @@
         return column.value?.pinned ?? null;
     });
 
-    function getColumnIndex(): number {
-        const element = cell.value;
-
-        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
-    }
-
     const isPinnedEdge = computed(() => {
         if (!pinnedSide.value) {
             return false;
@@ -141,4 +135,10 @@
 
         return style;
     });
+
+    function getColumnIndex(): number {
+        const element = cell.value;
+
+        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
+    }
 </script>

--- a/packages/components/src/component/FluxTableHeader.vue
+++ b/packages/components/src/component/FluxTableHeader.vue
@@ -140,15 +140,6 @@
         width
     }));
 
-    const unregisterColumn = registerColumn(header, columnDef);
-    onUnmounted(unregisterColumn);
-
-    function getColumnIndex(): number {
-        const element = header.value;
-
-        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
-    }
-
     const isPinnedEdge = computed(() => {
         if (!pinnedSide.value) {
             return false;
@@ -220,4 +211,13 @@
                 return 'arrow-up-arrow-down';
         }
     });
+
+    const unregisterColumn = registerColumn(header, columnDef);
+    onUnmounted(unregisterColumn);
+
+    function getColumnIndex(): number {
+        const element = header.value;
+
+        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
+    }
 </script>

--- a/packages/components/src/component/FluxTableRow.vue
+++ b/packages/components/src/component/FluxTableRow.vue
@@ -20,8 +20,6 @@
     import { useTableInjection } from '~flux/components/composable';
     import $style from '~flux/components/css/component/Table.module.scss';
 
-    const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
-
     const emit = defineEmits<{
         rowClick: [columnIndex: number, event: MouseEvent];
     }>();
@@ -39,6 +37,8 @@
         default(): VNode[];
     }>();
 
+    const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
+
     const row = useTemplateRef('row');
 
     const {activeRow} = useTableInjection();
@@ -55,17 +55,17 @@
         return activeRow.value === null || activeRow.value === row.value ? 0 : -1;
     });
 
-    onUnmounted(() => {
-        if (activeRow.value === row.value) {
-            activeRow.value = null;
-        }
-    });
-
     // Hiding the active row would leave every remaining row at tabindex -1,
     // making the table unreachable by Tab; release the roving anchor so the
     // visible rows become tab stops again (mirrors onUnmounted).
     watch(() => isHidden, hidden => {
         if (hidden && activeRow.value === row.value) {
+            activeRow.value = null;
+        }
+    });
+
+    onUnmounted(() => {
+        if (activeRow.value === row.value) {
             activeRow.value = null;
         }
     });

--- a/packages/components/src/component/FluxTableTreeCell.vue
+++ b/packages/components/src/component/FluxTableTreeCell.vue
@@ -40,15 +40,6 @@
     import FluxIcon from './FluxIcon.vue';
     import $style from '~flux/components/css/component/Table.module.scss';
 
-    const MARKER_COLOR_CLASS = {
-        gray: $style.treeMarkerGray,
-        primary: $style.treeMarkerPrimary,
-        danger: $style.treeMarkerDanger,
-        info: $style.treeMarkerInfo,
-        success: $style.treeMarkerSuccess,
-        warning: $style.treeMarkerWarning
-    } as const;
-
     const emit = defineEmits<{
         toggle: [];
     }>();
@@ -69,16 +60,19 @@
         default(): VNode[];
     }>();
 
+    const MARKER_COLOR_CLASS = {
+        gray: $style.treeMarkerGray,
+        primary: $style.treeMarkerPrimary,
+        danger: $style.treeMarkerDanger,
+        info: $style.treeMarkerInfo,
+        success: $style.treeMarkerSuccess,
+        warning: $style.treeMarkerWarning
+    } as const;
+
     const branch = useTemplateRef('branch');
     const translate = useTranslate();
 
     const {registerTreeNode} = useTableInjection();
-
-    // Register the branch so the table can measure it and draw this node's guide
-    // lines. Expansion state stays with the consuming application, which decides
-    // which rows are rendered.
-    const cleanup = registerTreeNode(branch, toRef(() => level));
-    onUnmounted(cleanup);
 
     const isFluxColor = computed(() => FLUX_COLORS.includes(color as FluxColor));
     const markerColorClass = computed(() => isFluxColor.value ? MARKER_COLOR_CLASS[color as FluxColor] : $style.treeMarkerCustom);
@@ -89,4 +83,10 @@
         left: `${level * TREE_STEP + (TREE_STEP - TREE_MARKER_SIZE) / 2}px`,
         ...(isFluxColor.value ? {} : {'--tree-marker-color': color})
     }));
+
+    // Register the branch so the table can measure it and draw this node's guide
+    // lines. Expansion state stays with the consuming application, which decides
+    // which rows are rendered.
+    const cleanup = registerTreeNode(branch, toRef(() => level));
+    onUnmounted(cleanup);
 </script>

--- a/packages/components/src/component/FluxTabs.vue
+++ b/packages/components/src/component/FluxTabs.vue
@@ -78,8 +78,8 @@
         }): VNode[];
     }>();
 
-    const baseId = useId();
     const isTransitioningBack = ref(false);
+    const baseId = useId();
 
     const rawChildren = computed(() => flattenVNodeTree(slots.default?.() ?? [])
         .filter(child => child.type !== Comment && child.type !== Text));
@@ -96,11 +96,11 @@
         }))
     );
 
-    function activate(index: number): void {
-        modelValue.value = index;
-    }
-
     watch(modelValue, (newIndex, oldIndex) => {
         isTransitioningBack.value = newIndex < oldIndex;
     });
+
+    function activate(index: number): void {
+        modelValue.value = index;
+    }
 </script>

--- a/packages/components/src/component/FluxTour.vue
+++ b/packages/components/src/component/FluxTour.vue
@@ -124,6 +124,13 @@
         readonly content?: () => VNode[];
     };
 
+    const emit = defineEmits<{
+        finish: [];
+        skip: [];
+        next: [number];
+        prev: [number];
+    }>();
+
     const active = defineModel<boolean>('active', {
         required: true
     });
@@ -140,18 +147,9 @@
         readonly root?: string | HTMLElement | (() => HTMLElement | null);
     }>();
 
-    const emit = defineEmits<{
-        finish: [];
-        skip: [];
-        next: [number];
-        prev: [number];
-    }>();
-
     const slots = defineSlots<{
         default(): VNode[];
     }>();
-
-    const translate = useTranslate();
 
     const popup = useTemplateRef<{ reposition(): void; resize(): void }>('popup');
     const popover = useTemplateRef<HTMLElement>('popover');
@@ -160,9 +158,11 @@
     const isStepping = ref(false);
     const titleId = useId();
 
-    useFocusTrap(popover, {disable: computed(() => !active.value)});
-
     let steppingTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const translate = useTranslate();
+
+    useFocusTrap(popover, {disable: computed(() => !active.value)});
 
     const items = computed<readonly TourItem[]>(() => {
         const vnodes = flattenVNodeTree(slots.default?.() ?? []);
@@ -207,6 +207,32 @@
             }
         }
     } as unknown as ComponentPublicInstance;
+
+    watch(step, (newStep, oldStep) => {
+        if (active.value && newStep !== oldStep) {
+            if (bodyViewport.value) {
+                bodyViewport.value.style.height = `${bodyViewport.value.offsetHeight}px`;
+            }
+
+            isStepping.value = true;
+            clearTimeout(steppingTimer);
+            steppingTimer = setTimeout(() => {
+                isStepping.value = false;
+            }, 300);
+        }
+    });
+
+    watch([active, step], async () => {
+        if (!active.value) {
+            targetRect.value = null;
+            isStepping.value = false;
+            clearTimeout(steppingTimer);
+            return;
+        }
+
+        await nextTick();
+        measure();
+    }, {immediate: true});
 
     function resolveScope(): ParentNode {
         if (!root) {
@@ -298,39 +324,13 @@
         }
     }
 
-    watch(step, (newStep, oldStep) => {
-        if (active.value && newStep !== oldStep) {
-            if (bodyViewport.value) {
-                bodyViewport.value.style.height = `${bodyViewport.value.offsetHeight}px`;
-            }
-
-            isStepping.value = true;
-            clearTimeout(steppingTimer);
-            steppingTimer = setTimeout(() => {
-                isStepping.value = false;
-            }, 300);
-        }
-    });
-
-    watch([active, step], async () => {
-        if (!active.value) {
-            targetRect.value = null;
-            isStepping.value = false;
-            clearTimeout(steppingTimer);
-            return;
-        }
-
-        await nextTick();
-        measure();
-    }, {immediate: true});
-
     if (!isSSR) {
-        const onRemeasure = () => {
+        function onRemeasure(): void {
             if (active.value && targetRect.value) {
                 const resolved = resolveTarget();
                 targetRect.value = resolved ? resolved.getBoundingClientRect() : null;
             }
-        };
+        }
 
         useEventListener(ref(window), 'resize', onRemeasure);
         useEventListener(ref(window), 'scroll', onRemeasure, {capture: true, passive: true});

--- a/packages/components/src/component/FluxTourItem.vue
+++ b/packages/components/src/component/FluxTourItem.vue
@@ -1,3 +1,9 @@
+<template>
+    <span
+        aria-hidden="true"
+        style="display: none"/>
+</template>
+
 <script
     lang="ts"
     setup>
@@ -19,9 +25,3 @@
         default(): VNode[];
     }>();
 </script>
-
-<template>
-    <span
-        aria-hidden="true"
-        style="display: none"/>
-</template>

--- a/packages/components/src/component/FluxWindow.vue
+++ b/packages/components/src/component/FluxWindow.vue
@@ -1,6 +1,6 @@
 <template>
     <FluxWindowTransition :is-back="isBack">
-        <template v-for="(_, slot) of slots">
+        <template v-for="(_, slot) of slots" :key="slot">
             <slot
                 v-if="slot === view"
                 v-bind="{back, navigate}"

--- a/packages/components/src/component/calendar/FluxCalendarItemDisplay.vue
+++ b/packages/components/src/component/calendar/FluxCalendarItemDisplay.vue
@@ -1,9 +1,24 @@
+<template>
+    <button
+        ref="root"
+        :class="itemClasses"
+        :draggable="canDrag"
+        :tabindex="canDrag ? 0 : undefined"
+        type="button"
+        @click="onClick"
+        @dragstart="onDragStart"
+        @dragend="onDragEnd"
+        @keydown="handleKeyDown">
+        <RenderItemContent :render="data.renderContent"/>
+    </button>
+</template>
+
 <script
     lang="ts"
     setup>
     import { useKeyboardGrab } from '@flux-ui/internals';
     import { clsx } from 'clsx';
-    import { computed, defineComponent, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue';
+    import { computed, defineComponent, onBeforeUnmount, onMounted, ref, toRef, useTemplateRef, watch } from 'vue';
     import { useCalendarInjection } from '~flux/components/composable';
     import type { FluxCalendarItemData } from '~flux/components/data';
     import $style from '~flux/components/css/component/Calendar.module.scss';
@@ -13,7 +28,7 @@
     }>();
 
     const dragContext = useCalendarInjection();
-    const root = ref<HTMLButtonElement | null>(null);
+    const root = useTemplateRef<HTMLButtonElement>('root');
 
     const canDrag = computed(() => dragContext?.isDraggable.value === true);
 
@@ -58,6 +73,27 @@
         data.allDay && $style.isAllDay
     ));
 
+    watch(() => data.id, (_newId, _oldId) => {
+        if (!root.value) {
+            return;
+        }
+
+        dragContext?.unregisterItemElement(root.value);
+        dragContext?.registerItemElement(root.value, data.id);
+    });
+
+    onMounted(() => {
+        if (root.value) {
+            dragContext?.registerItemElement(root.value, data.id);
+        }
+    });
+
+    onBeforeUnmount(() => {
+        if (root.value) {
+            dragContext?.unregisterItemElement(root.value);
+        }
+    });
+
     function onClick(evt: MouseEvent): void {
         data.handleClick(evt);
     }
@@ -78,40 +114,4 @@
     function onDragEnd(): void {
         dragContext?.onItemDragEnd(data.id);
     }
-
-    onMounted(() => {
-        if (root.value) {
-            dragContext?.registerItemElement(root.value, data.id);
-        }
-    });
-
-    onBeforeUnmount(() => {
-        if (root.value) {
-            dragContext?.unregisterItemElement(root.value);
-        }
-    });
-
-    watch(() => data.id, (_newId, _oldId) => {
-        if (!root.value) {
-            return;
-        }
-
-        dragContext?.unregisterItemElement(root.value);
-        dragContext?.registerItemElement(root.value, data.id);
-    });
 </script>
-
-<template>
-    <button
-        ref="root"
-        :class="itemClasses"
-        :draggable="canDrag"
-        :tabindex="canDrag ? 0 : undefined"
-        type="button"
-        @click="onClick"
-        @dragstart="onDragStart"
-        @dragend="onDragEnd"
-        @keydown="handleKeyDown">
-        <RenderItemContent :render="data.renderContent"/>
-    </button>
-</template>

--- a/packages/components/src/component/calendar/FluxCalendarMonthView.vue
+++ b/packages/components/src/component/calendar/FluxCalendarMonthView.vue
@@ -4,13 +4,13 @@
             :key="viewDate.month"
             :class="$style.calendarCells"
             role="grid">
-            <template v-for="day of days">
+            <template v-for="day of days" :key="day">
                 <div :class="$style.calendarDay">
                     {{ day }}
                 </div>
             </template>
 
-            <template v-for="date of dates">
+            <template v-for="date of dates" :key="date.toSQLDate()">
                 <div
                     :class="clsx(
                         $style.calendarEntry,
@@ -75,10 +75,6 @@
 
     const dropTargetDate = ref<string | null>(null);
 
-    function isToday(date: DateTime): boolean {
-        return date.hasSame(DateTime.now(), 'day');
-    }
-
     const itemsByDate = computed(() => {
         const map = new Map<string, FluxCalendarItemData[]>();
 
@@ -100,6 +96,10 @@
 
         return map;
     });
+
+    function isToday(date: DateTime): boolean {
+        return date.hasSame(DateTime.now(), 'day');
+    }
 
     function getItemsForDate(forDate: DateTime): FluxCalendarItemData[] {
         const key = forDate.toSQLDate();

--- a/packages/components/src/component/calendar/FluxCalendarTimeGridView.vue
+++ b/packages/components/src/component/calendar/FluxCalendarTimeGridView.vue
@@ -164,13 +164,14 @@
         readonly dayCount: 1 | 2 | 7;
     }>();
 
-    const translate = useTranslate();
     const dropTargetDay = ref<string | null>(null);
     const dropTargetMinutes = ref<number | null>(null);
     const dropTargetAllDay = ref<string | null>(null);
 
     const resizeState = ref<ResizeState | null>(null);
     const resizePreview = ref<{ id: string | number; date: DateTime; duration: number } | null>(null);
+
+    const translate = useTranslate();
 
     const hours = computed<number[]>(() => {
         const [from, to] = hourRange;
@@ -192,6 +193,18 @@
     } as Record<string, string>));
 
     const viewKey = computed<string>(() => `${dayCount}-${viewDates[0].toISODate() ?? ''}`);
+
+    // Precompute the positioned items per day so re-renders caused by drag-hover state
+    // (dropTargetMinutes updates on every dragover) don't redo the lane layout for all columns.
+    const timedItemsByDay = computed(() => {
+        const map = new Map<string | null, Positioned[]>();
+
+        for (const d of viewDates) {
+            map.set(d.toSQLDate(), computeTimedItems(d));
+        }
+
+        return map;
+    });
 
     function isToday(d: DateTime): boolean {
         return d.hasSame(DateTime.now(), 'day');
@@ -218,18 +231,6 @@
 
         return items.filter(item => item.allDay && item.date.toSQLDate() === dStr);
     }
-
-    // Precompute the positioned items per day so re-renders caused by drag-hover state
-    // (dropTargetMinutes updates on every dragover) don't redo the lane layout for all columns.
-    const timedItemsByDay = computed(() => {
-        const map = new Map<string | null, Positioned[]>();
-
-        for (const d of viewDates) {
-            map.set(d.toSQLDate(), computeTimedItems(d));
-        }
-
-        return map;
-    });
 
     function getTimedItems(d: DateTime): Positioned[] {
         return unref(timedItemsByDay).get(d.toSQLDate()) ?? [];

--- a/packages/components/src/component/primitive/AnchorPopup.vue
+++ b/packages/components/src/component/primitive/AnchorPopup.vue
@@ -51,6 +51,23 @@
         width: null as number | null
     });
 
+    useMutationObserver(popupRef, () => {
+        reposition();
+    }, {childList: true, subtree: true});
+
+    watchEffect(() => {
+        if (!anchor || (!isHtmlElement(anchor) && !anchor.$el)) {
+            return;
+        }
+
+        anchorRef.value = isHtmlElement(anchor) ? anchor : anchor.$el;
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(resize);
+            requestAnimationFrame(reposition);
+        });
+    });
+
     onMounted(() => {
         window.addEventListener('resize', onResize, {passive: true});
         window.addEventListener('scroll', onScroll, {capture: true, passive: true});
@@ -63,10 +80,6 @@
         window.removeEventListener('resize', onResize);
         window.removeEventListener('scroll', onScroll, {capture: true});
     });
-
-    useMutationObserver(popupRef, () => {
-        reposition();
-    }, {childList: true, subtree: true});
 
     function reposition(): void {
         const anchor = unref(anchorRef);
@@ -210,18 +223,5 @@
     defineExpose({
         reposition,
         resize
-    });
-
-    watchEffect(() => {
-        if (!anchor || (!isHtmlElement(anchor) && !anchor.$el)) {
-            return;
-        }
-
-        anchorRef.value = isHtmlElement(anchor) ? anchor : anchor.$el;
-
-        requestAnimationFrame(() => {
-            requestAnimationFrame(resize);
-            requestAnimationFrame(reposition);
-        });
     });
 </script>

--- a/packages/components/src/component/primitive/CoordinatePicker.vue
+++ b/packages/components/src/component/primitive/CoordinatePicker.vue
@@ -47,16 +47,27 @@
         readonly step?: number | [number, number];
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
     const rootRef = useTemplateRef('root');
-
     const isDragging = ref(false);
+    const pointerId = ref<number | null>(null);
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
 
     const max = computed(() => Array.isArray(maxProp) ? maxProp : [maxProp, maxProp]);
     const min = computed(() => Array.isArray(minProp) ? minProp : [minProp, minProp]);
     const step = computed(() => Array.isArray(stepProp) ? stepProp : [stepProp, stepProp]);
+    const thumbPosition = computed<[number, number]>(() => [
+        normalize(unref(modelValue)[0], unref(min)[0], unref(max)[0]),
+        normalize(unref(modelValue)[1], unref(min)[1], unref(max)[1])
+    ]);
 
-    const pointerId = ref<number | null>(null);
+    watch(isDragging, isDragging => emit('dragging', isDragging));
+
+    onUnmounted(() => {
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointercancel', onPointerUp);
+        document.removeEventListener('pointerup', onPointerUp);
+    });
 
     function normalize(value: number, axisMin: number, axisMax: number): number {
         const span = axisMax - axisMin;
@@ -67,11 +78,6 @@
 
         return Math.max(0, Math.min(1, (value - axisMin) / span));
     }
-
-    const thumbPosition = computed<[number, number]>(() => [
-        normalize(unref(modelValue)[0], unref(min)[0], unref(max)[0]),
-        normalize(unref(modelValue)[1], unref(min)[1], unref(max)[1])
-    ]);
 
     function getStepDecimals(stepValue: number): number {
         const stepString = stepValue.toString();
@@ -196,12 +202,4 @@
         document.removeEventListener('pointercancel', onPointerUp);
         document.removeEventListener('pointerup', onPointerUp);
     }
-
-    watch(isDragging, isDragging => emit('dragging', isDragging));
-
-    onUnmounted(() => {
-        document.removeEventListener('pointermove', onPointerMove);
-        document.removeEventListener('pointercancel', onPointerUp);
-        document.removeEventListener('pointerup', onPointerUp);
-    });
 </script>

--- a/packages/components/src/component/primitive/FilterOptionBase.vue
+++ b/packages/components/src/component/primitive/FilterOptionBase.vue
@@ -20,7 +20,8 @@
 
         <template
             v-else
-            v-for="option of options">
+            v-for="option of options"
+            :key="isFluxFilterOptionItem(option) ? String(option.value) : option.title">
             <FluxMenuSubHeader
                 v-if="isFluxFilterOptionHeader(option)"
                 :label="option.title"/>
@@ -55,8 +56,6 @@
         default: ''
     });
 
-    const searchInputRef = useTemplateRef<{ focus(): void }>('search');
-
     defineProps<{
         readonly isLoading?: boolean;
         readonly isSearchable?: boolean;
@@ -65,11 +64,13 @@
         readonly searchPlaceholder?: string;
     }>();
 
-    function select(option: FluxFilterOptionItem): void {
-        emit('select', option.value);
-    }
+    const searchInputRef = useTemplateRef<{ focus(): void }>('search');
 
     onMounted(() => {
         requestAnimationFrame(() => searchInputRef.value?.focus());
     });
+
+    function select(option: FluxFilterOptionItem): void {
+        emit('select', option.value);
+    }
 </script>

--- a/packages/components/src/component/primitive/SelectBase.vue
+++ b/packages/components/src/component/primitive/SelectBase.vue
@@ -110,11 +110,11 @@
                                 :icon-leading="item.icon"
                                 :label="item.label"/>
 
-                            <template v-for="(subItem, index) of subItems">
+                            <template v-for="subItem of subItems">
                                 <FluxMenuItem
                                     v-if="isFluxFormSelectOption(subItem)"
                                     ref="optionElements"
-                                    :key="index"
+                                    :key="subItem.value ?? 'null option'"
                                     :id="optionId(subItem.value)"
                                     :command="subItem.command"
                                     :command-icon="subItem.commandIcon"
@@ -132,7 +132,7 @@
                         <FluxMenuItem
                             v-if="isFluxFormSelectOption(item)"
                             ref="optionElements"
-                            :key="`item-${index}`"
+                            :key="item.value ?? 'null option'"
                             :id="optionId(item.value)"
                             :command="item.command"
                             :command-icon="item.commandIcon"
@@ -174,6 +174,10 @@
     import AnchorPopup from './AnchorPopup.vue';
     import $style from '~flux/components/css/component/Form.module.scss';
 
+    defineOptions({
+        inheritAttrs: false
+    });
+
     const emit = defineEmits<{
         keyDown: [KeyboardEvent];
         deselect: [string | number | null];
@@ -186,10 +190,6 @@
 
     const modelSearch = defineModel<string>('searchQuery', {
         default: ''
-    });
-
-    defineOptions({
-        inheritAttrs: false
     });
 
     const {
@@ -213,11 +213,6 @@
         readonly selected: FluxFormSelectOption[];
     }>();
 
-    const disabled = useDisabled(toRef(() => componentDisabled));
-    const {id, describedBy} = useFormFieldInjection();
-    const translate = useTranslate();
-    const popupId = useId();
-
     const anchorRef = useTemplateRef<ComponentPublicInstance>('anchor');
     const anchorPopupRef = useTemplateRef<ComponentPublicInstance>('anchorPopup');
     const optionElementRefs = useTemplateRef<typeof FluxMenuItem[]>('optionElements');
@@ -225,6 +220,11 @@
 
     const highlightedIndex = ref(INITIAL_HIGHLIGHTED_INDEX);
     const isKeyboardAction = ref(false);
+
+    const disabled = useDisabled(toRef(() => componentDisabled));
+    const {id, describedBy} = useFormFieldInjection();
+    const translate = useTranslate();
+    const popupId = useId();
 
     const focusElement = computed(() => {
         // The search input's template ref resolves to FluxFormInput's wrapper element, which is not
@@ -256,6 +256,51 @@
         focusElement,
         disabled,
         readonly: toRef(() => !!isReadonly)
+    });
+
+    watch(highlightedIndex, highlightedIndex => {
+        const options = unref(optionElementRefs)!;
+        options[highlightedIndex]?.$el.scrollIntoView({
+            block: 'center'
+        });
+    });
+
+    watch(isPopupOpen, isPopupOpen => {
+        if (!isPopupOpen) {
+            emit('close');
+            return;
+        }
+
+        nextTick(() => {
+            const options = unref(optionElementRefs);
+
+            if (!options || isMultiple) {
+                return;
+            }
+
+            const selectedIndex = options.findIndex(o => 'isActive' in o.$props && o.$props.isActive);
+            const option = options[selectedIndex];
+
+            if (!option) {
+                return;
+            }
+
+            option.$el.scrollIntoView({
+                block: 'center'
+            });
+        });
+
+        emit('open');
+    });
+
+    watch(modelSearch, searchQuery => emit('search', searchQuery));
+
+    watch([() => options, isPopupOpen], () => highlightedIndex.value = INITIAL_HIGHLIGHTED_INDEX);
+
+    onMounted(() => {
+        if (autoFocus) {
+            nextTick(() => unrefTemplateElement(anchorRef)?.focus());
+        }
     });
 
     function optionId(value: string | number | null): string {
@@ -362,49 +407,4 @@
     function onKeyUp(): void {
         isKeyboardAction.value = false;
     }
-
-    watch(highlightedIndex, highlightedIndex => {
-        const options = unref(optionElementRefs)!;
-        options[highlightedIndex]?.$el.scrollIntoView({
-            block: 'center'
-        });
-    });
-
-    watch(isPopupOpen, isPopupOpen => {
-        if (!isPopupOpen) {
-            emit('close');
-            return;
-        }
-
-        nextTick(() => {
-            const options = unref(optionElementRefs);
-
-            if (!options || isMultiple) {
-                return;
-            }
-
-            const selectedIndex = options.findIndex(o => 'isActive' in o.$props && o.$props.isActive);
-            const option = options[selectedIndex];
-
-            if (!option) {
-                return;
-            }
-
-            option.$el.scrollIntoView({
-                block: 'center'
-            });
-        });
-
-        emit('open');
-    });
-
-    watch(modelSearch, searchQuery => emit('search', searchQuery));
-
-    watch([() => options, isPopupOpen], () => highlightedIndex.value = INITIAL_HIGHLIGHTED_INDEX);
-
-    onMounted(() => {
-        if (autoFocus) {
-            nextTick(() => unrefTemplateElement(anchorRef)?.focus());
-        }
-    });
 </script>

--- a/packages/components/src/component/primitive/SelectBase.vue
+++ b/packages/components/src/component/primitive/SelectBase.vue
@@ -110,11 +110,12 @@
                                 :icon-leading="item.icon"
                                 :label="item.label"/>
 
-                            <template v-for="subItem of subItems">
+                            <template
+                                v-for="subItem of subItems"
+                                :key="subItem.value ?? 'null option'">
                                 <FluxMenuItem
                                     v-if="isFluxFormSelectOption(subItem)"
                                     ref="optionElements"
-                                    :key="subItem.value ?? 'null option'"
                                     :id="optionId(subItem.value)"
                                     :command="subItem.command"
                                     :command-icon="subItem.commandIcon"

--- a/packages/components/src/component/primitive/TreeNodeRenderer.vue
+++ b/packages/components/src/component/primitive/TreeNodeRenderer.vue
@@ -47,6 +47,10 @@
     import FluxIcon from '../FluxIcon.vue';
     import $style from '~flux/components/css/component/primitive/TreeNode.module.scss';
 
+    defineOptions({
+        inheritAttrs: false
+    });
+
     const emit = defineEmits<{
         expandClick: [MouseEvent];
     }>();
@@ -63,10 +67,6 @@
     defineSlots<{
         trailing?(props: { node: TreeFlatNode<TOption> }): any;
     }>();
-
-    defineOptions({
-        inheritAttrs: false
-    });
 
     const dotColor = computed(() => getLevelColor(node.depth, levelColors));
 

--- a/packages/flow/src/component/FluxFlow.vue
+++ b/packages/flow/src/component/FluxFlow.vue
@@ -89,11 +89,13 @@
     setup>
     import { FluxBadge } from '@flux-ui/components';
     import { clsx } from 'clsx';
-    import { computed, onBeforeUnmount, onMounted, provide, ref, toRef, watch, type CSSProperties } from 'vue';
+    import { computed, onBeforeUnmount, onMounted, provide, ref, toRef, useTemplateRef, watch, type CSSProperties } from 'vue';
     import { useFlowController } from '~flux/flow/composable/private';
     import { FluxFlowInjectionKey, type FluxFlowViewport } from '~flux/flow/data';
     import $style from '~flux/flow/css/component/Flow.module.scss';
     import $edge from '~flux/flow/css/component/FlowConnection.module.scss';
+
+    const viewport = defineModel<FluxFlowViewport>('viewport');
 
     const {
         background = 'none',
@@ -103,8 +105,7 @@
         minZoom = 0.4,
         maxZoom = 2,
         zoomStep = 0.2,
-        gridSize = 24,
-        viewport: viewportProp
+        gridSize = 24
     } = defineProps<{
         readonly background?: 'dots' | 'grid' | 'none';
         readonly interactive?: boolean;
@@ -114,11 +115,6 @@
         readonly maxZoom?: number;
         readonly zoomStep?: number;
         readonly gridSize?: number;
-        readonly viewport?: FluxFlowViewport;
-    }>();
-
-    const emit = defineEmits<{
-        'update:viewport': [FluxFlowViewport];
     }>();
 
     defineSlots<{
@@ -128,7 +124,19 @@
     // Room reserved above the top row for a card's floating badge, so `padding`
     // can default to 0 without clipping badges.
     const BADGE_ROOM = 42;
-    const topPadding = () => Math.max(padding, BADGE_ROOM);
+
+    // A press that lands on an interactive control inside a card must keep its own
+    // click: starting a pan captures the pointer and would swallow it. Opt any other
+    // content out of panning with a `data-nopan` attribute.
+    const NO_PAN_SELECTOR = 'a, button, input, select, textarea, label, [role="button"], [role="switch"], [contenteditable], [data-nopan]';
+
+    const clip = useTemplateRef<HTMLElement>('clip');
+    const isPanning = ref(false);
+    const isReady = ref(false);
+    const hoveredEdge = ref<number | null>(null);
+
+    let lastPointer: { x: number; y: number } | null = null;
+    let initialFrame = 0;
 
     const controller = useFlowController({
         isStatic: toRef(() => !interactive),
@@ -139,19 +147,6 @@
     });
 
     provide(FluxFlowInjectionKey, controller);
-
-    const clip = ref<HTMLElement | null>(null);
-    const isPanning = ref(false);
-    const isReady = ref(false);
-    const hoveredEdge = ref<number | null>(null);
-
-    let lastPointer: { x: number; y: number } | null = null;
-    let initialFrame = 0;
-
-    // A press that lands on an interactive control inside a card must keep its own
-    // click: starting a pan captures the pointer and would swallow it. Opt any other
-    // content out of panning with a `data-nopan` attribute.
-    const NO_PAN_SELECTOR = 'a, button, input, select, textarea, label, [role="button"], [role="switch"], [contenteditable], [data-nopan]';
 
     const edgeList = computed(() => Array.from(controller.edges.values()));
 
@@ -214,8 +209,68 @@
             : '0 0'
     }));
 
-    const sameViewport = (a: FluxFlowViewport | undefined, b: FluxFlowViewport | undefined): boolean =>
-        !!a && !!b && a.x === b.x && a.y === b.y && a.zoom === b.zoom;
+    watch(viewport, value => {
+        if (value && !sameViewport(value, controller.viewport.value)) {
+            controller.setViewport(value);
+        }
+    }, {deep: true});
+
+    watch(controller.viewport, value => {
+        if (!sameViewport(value, viewport.value)) {
+            viewport.value = value;
+        }
+    });
+
+    onMounted(() => {
+        controller.setClipElement(clip.value);
+
+        // Natural layout drives its own view through worldStyle; only an interactive
+        // viewport needs an initial view.
+        if (!interactive) {
+            return;
+        }
+
+        if (viewport.value) {
+            controller.setViewport(viewport.value);
+            initialFrame = requestAnimationFrame(() => (isReady.value = true));
+            return;
+        }
+
+        initialFrame = requestAnimationFrame(() => (initialFrame = requestAnimationFrame(() => {
+            const startNode = start ? controller.getNode(start) : undefined;
+            const rect = clip.value?.getBoundingClientRect();
+
+            if (startNode && rect) {
+                // Centre the viewport on the designated start card, at 100% zoom.
+                const {x, y} = startNode.position.value;
+                const {width, height} = startNode.size.value;
+                controller.setViewport({
+                    x: rect.width / 2 - (x + width / 2),
+                    y: rect.height / 2 - (y + height / 2),
+                    zoom: 1
+                });
+            } else {
+                // Start at 100% zoom, aligned to the flow's top-left start point.
+                const bounds = controller.bounds.value;
+
+                if (bounds) {
+                    controller.setViewport({x: padding - bounds.minX, y: topPadding() - bounds.minY, zoom: 1});
+                }
+            }
+
+            initialFrame = requestAnimationFrame(() => (isReady.value = true));
+        })));
+    });
+
+    onBeforeUnmount(() => cancelAnimationFrame(initialFrame));
+
+    function topPadding(): number {
+        return Math.max(padding, BADGE_ROOM);
+    }
+
+    function sameViewport(a: FluxFlowViewport | undefined, b: FluxFlowViewport | undefined): boolean {
+        return !!a && !!b && a.x === b.x && a.y === b.y && a.zoom === b.zoom;
+    }
 
     function onPointerDown(event: PointerEvent): void {
         if (!interactive || event.button !== 0) {
@@ -263,61 +318,6 @@
         const factor = event.deltaY < 0 ? 1 + zoomStep : 1 / (1 + zoomStep);
         controller.zoomAt(event.clientX, event.clientY, factor);
     }
-
-    watch(() => viewportProp, value => {
-        if (value && !sameViewport(value, controller.viewport.value)) {
-            controller.setViewport(value);
-        }
-    }, {deep: true});
-
-    watch(controller.viewport, value => {
-        if (!sameViewport(value, viewportProp)) {
-            emit('update:viewport', value);
-        }
-    });
-
-    onMounted(() => {
-        controller.setClipElement(clip.value);
-
-        // Natural layout drives its own view through worldStyle; only an interactive
-        // viewport needs an initial view.
-        if (!interactive) {
-            return;
-        }
-
-        if (viewportProp) {
-            controller.setViewport(viewportProp);
-            initialFrame = requestAnimationFrame(() => (isReady.value = true));
-            return;
-        }
-
-        initialFrame = requestAnimationFrame(() => (initialFrame = requestAnimationFrame(() => {
-            const startNode = start ? controller.getNode(start) : undefined;
-            const rect = clip.value?.getBoundingClientRect();
-
-            if (startNode && rect) {
-                // Centre the viewport on the designated start card, at 100% zoom.
-                const {x, y} = startNode.position.value;
-                const {width, height} = startNode.size.value;
-                controller.setViewport({
-                    x: rect.width / 2 - (x + width / 2),
-                    y: rect.height / 2 - (y + height / 2),
-                    zoom: 1
-                });
-            } else {
-                // Start at 100% zoom, aligned to the flow's top-left start point.
-                const bounds = controller.bounds.value;
-
-                if (bounds) {
-                    controller.setViewport({x: padding - bounds.minX, y: topPadding() - bounds.minY, zoom: 1});
-                }
-            }
-
-            initialFrame = requestAnimationFrame(() => (isReady.value = true));
-        })));
-    });
-
-    onBeforeUnmount(() => cancelAnimationFrame(initialFrame));
 
     defineExpose({
         controller,

--- a/packages/flow/src/component/FluxFlow.vue
+++ b/packages/flow/src/component/FluxFlow.vue
@@ -269,6 +269,10 @@
     }
 
     function sameViewport(a: FluxFlowViewport | undefined, b: FluxFlowViewport | undefined): boolean {
+        if (a === b) {
+            return true;
+        }
+
         return !!a && !!b && a.x === b.x && a.y === b.y && a.zoom === b.zoom;
     }
 

--- a/packages/flow/src/component/FluxFlowConnection.vue
+++ b/packages/flow/src/component/FluxFlowConnection.vue
@@ -38,11 +38,8 @@
         warning: true
     };
 
-    const controller = useFluxFlowInjection();
     const uid = getCurrentInstance()!.uid;
-
-    const resolveColor = (value: string | undefined, fallback: string): string =>
-        value ? (Object.hasOwn(FLUX_COLORS, value) ? `var(--${value}-500)` : value) : fallback;
+    const controller = useFluxFlowInjection();
 
     const hasProgress = computed(() => props.progressValue !== undefined && props.progressValue !== null);
 
@@ -123,4 +120,8 @@
     controller.registerEdge({id: uid, spec});
 
     onBeforeUnmount(() => controller.unregisterEdge(uid));
+
+    function resolveColor(value: string | undefined, fallback: string): string {
+        return value ? (Object.hasOwn(FLUX_COLORS, value) ? `var(--${value}-500)` : value) : fallback;
+    }
 </script>

--- a/packages/flow/src/component/FluxFlowNode.vue
+++ b/packages/flow/src/component/FluxFlowNode.vue
@@ -10,7 +10,7 @@
 <script
     lang="ts"
     setup>
-    import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
+    import { computed, onBeforeUnmount, onMounted, shallowRef, useTemplateRef, watch } from 'vue';
     import { useFluxFlowInjection } from '~flux/flow/composable';
     import type { FluxFlowSize } from '~flux/flow/data';
     import $style from '~flux/flow/css/component/FlowNode.module.scss';
@@ -21,21 +21,19 @@
         readonly y: number;
     }>();
 
-    const controller = useFluxFlowInjection();
-
-    const el = ref<HTMLElement | null>(null);
+    const el = useTemplateRef<HTMLElement>('el');
     const size = shallowRef<FluxFlowSize>({width: 0, height: 0});
-    const position = computed(() => ({x: props.x, y: props.y}));
 
     let observer: ResizeObserver | null = null;
 
-    function measure(): void {
-        const node = el.value;
+    const controller = useFluxFlowInjection();
 
-        if (node) {
-            size.value = {width: node.offsetWidth, height: node.offsetHeight};
-        }
-    }
+    const position = computed(() => ({x: props.x, y: props.y}));
+
+    watch(() => props.id, (next, previous) => {
+        controller.unregisterNode(previous);
+        controller.registerNode({id: next, position, size, element: el});
+    });
 
     onMounted(() => {
         controller.registerNode({id: props.id, position, size, element: el});
@@ -53,8 +51,11 @@
         controller.unregisterNode(props.id);
     });
 
-    watch(() => props.id, (next, previous) => {
-        controller.unregisterNode(previous);
-        controller.registerNode({id: next, position, size, element: el});
-    });
+    function measure(): void {
+        const node = el.value;
+
+        if (node) {
+            size.value = {width: node.offsetWidth, height: node.offsetHeight};
+        }
+    }
 </script>

--- a/packages/statistics/src/component/FluxStatisticsLegend.vue
+++ b/packages/statistics/src/component/FluxStatisticsLegend.vue
@@ -39,14 +39,17 @@
         readonly variant?: FluxStatisticsLegendVariant;
     }>();
 
+    const listRef = useTemplateRef('list');
+
     const slots = useSlots();
     const legendContext = inject(FluxStatisticsChartLegendInjectionKey, null);
-    const listRef = useTemplateRef('list');
 
     // One tab stop for the whole legend; arrow keys move focus between items. Bidirectional handles
     // every layout (detailed column, compact row/wrap/column) since it resolves the next item
     // geometrically. Focusing an item drives the same hover sync as the mouse.
     useFocusZone(listRef, {direction: 'bidirectional'});
+
+    provide(FluxStatisticsLegendVariantInjectionKey, toRef(() => variant));
 
     const autoItems = computed(() => legendContext?.items.value ?? []);
 
@@ -57,8 +60,6 @@
 
         return $style.statisticsLegend;
     });
-
-    provide(FluxStatisticsLegendVariantInjectionKey, toRef(() => variant));
 
     function onItemMouseEnter(index: number): void {
         if (legendContext) {

--- a/packages/statistics/src/component/FluxStatisticsPercentageBar.vue
+++ b/packages/statistics/src/component/FluxStatisticsPercentageBar.vue
@@ -6,7 +6,7 @@
         <div :class="clsx($style.statisticsPercentageBarTrack, hoveredIndex !== null && $style.isHoverActive)">
             <FluxTooltip
                 v-for="(item, index) of normalizedItems"
-                :key="index">
+                :key="item.label">
                 <template #content>
                     <div :class="$style.statisticsPercentageBarTooltip">
                         <FluxIcon

--- a/packages/visuals/src/component/FluxVisualAnimatedColors.vue
+++ b/packages/visuals/src/component/FluxVisualAnimatedColors.vue
@@ -32,14 +32,13 @@
     }>();
 
     const canvasRef = useTemplateRef('canvas');
-    const componentId = useComponentId();
-    const inView = useInView(canvasRef, {initial: true});
-
     const contextRef = ref<CanvasRenderingContext2D>();
     const animationFrame = ref(0);
     const tick = ref(0);
     const size = ref<{ width: number; height: number; } | null>(null);
 
+    const componentId = useComponentId();
+    const inView = useInView(canvasRef, {initial: true});
     const reducedMotion = prefersReducedMotion();
 
     const polygons = computed(() => {
@@ -71,6 +70,45 @@
 
         return polygons;
     });
+
+    watch(canvasRef, (canvas, _, onCleanup) => {
+        if (!canvas) {
+            contextRef.value = undefined;
+            size.value = null;
+            return;
+        }
+
+        contextRef.value = canvas.getContext('2d', {
+            alpha: true,
+            colorSpace: 'display-p3'
+        })!;
+
+        if (typeof ResizeObserver === 'undefined') {
+            size.value = {width: canvas.offsetWidth, height: canvas.offsetHeight};
+            canvas.width = canvas.offsetWidth;
+            canvas.height = canvas.offsetHeight;
+            return;
+        }
+
+        const observer = new ResizeObserver(() => {
+            const width = canvas.offsetWidth;
+            const height = canvas.offsetHeight;
+
+            if (!width || !height || (size.value?.width === width && size.value?.height === height)) {
+                return;
+            }
+
+            canvas.width = width;
+            canvas.height = height;
+            size.value = {width, height};
+        });
+
+        observer.observe(canvas);
+
+        onCleanup(() => observer.disconnect());
+    }, {immediate: true});
+
+    watch([polygons, () => opacity, size, inView], () => restart());
 
     onBeforeUnmount(() => cancel());
 
@@ -145,43 +183,4 @@
 
         schedule();
     }
-
-    watch(canvasRef, (canvas, _, onCleanup) => {
-        if (!canvas) {
-            contextRef.value = undefined;
-            size.value = null;
-            return;
-        }
-
-        contextRef.value = canvas.getContext('2d', {
-            alpha: true,
-            colorSpace: 'display-p3'
-        })!;
-
-        if (typeof ResizeObserver === 'undefined') {
-            size.value = {width: canvas.offsetWidth, height: canvas.offsetHeight};
-            canvas.width = canvas.offsetWidth;
-            canvas.height = canvas.offsetHeight;
-            return;
-        }
-
-        const observer = new ResizeObserver(() => {
-            const width = canvas.offsetWidth;
-            const height = canvas.offsetHeight;
-
-            if (!width || !height || (size.value?.width === width && size.value?.height === height)) {
-                return;
-            }
-
-            canvas.width = width;
-            canvas.height = height;
-            size.value = {width, height};
-        });
-
-        observer.observe(canvas);
-
-        onCleanup(() => observer.disconnect());
-    }, {immediate: true});
-
-    watch([polygons, () => opacity, size, inView], () => restart());
 </script>

--- a/packages/visuals/src/component/FluxVisualFlickeringGrid.vue
+++ b/packages/visuals/src/component/FluxVisualFlickeringGrid.vue
@@ -49,60 +49,6 @@
         return context.getImageData(0, 0, 1, 1).data;
     });
 
-    function draw(context: CanvasRenderingContext2D, width: number, height: number, columns: number, rows: number, squares: Float32Array, dpr: number): void {
-        context.clearRect(0, 0, width * dpr, height * dpr);
-
-        const [r, g, b] = unref(rgb);
-
-        for (let i = 0; i < columns; ++i) {
-            for (let j = 0; j < rows; ++j) {
-                const opacity = squares[i * rows + j];
-                context.fillStyle = `rgb(${r} ${g} ${b} / ${opacity})`;
-                context.fillRect(
-                    (i * (size + gap) + width / 2 - (columns / 2 * (size + gap) - gap / 2)) * dpr,
-                    (j * (size + gap) + height / 2 - (rows / 2 * (size + gap) - gap / 2)) * dpr,
-                    size * dpr,
-                    size * dpr
-                );
-            }
-        }
-    }
-
-    function setup(canvas: HTMLCanvasElement) {
-        const width = canvas.clientWidth;
-        const height = canvas.clientHeight;
-        const dpr = window.devicePixelRatio || 1;
-        canvas.width = width * dpr;
-        canvas.height = height * dpr;
-        canvas.style.width = `${width}px`;
-        canvas.style.height = `${height}px`;
-
-        const columns = Math.ceil(width / (size + gap));
-        const rows = Math.ceil(height / (size + gap));
-        const squares = new Float32Array(columns * rows);
-
-        for (let i = 0; i < squares.length; ++i) {
-            squares[i] = mulberry.next() * maxOpacity;
-        }
-
-        return {
-            width,
-            height,
-            columns,
-            rows,
-            squares,
-            dpr
-        };
-    }
-
-    function tick(squares: Float32Array, delta: number): void {
-        for (let i = 0; i < squares.length; ++i) {
-            if (mulberry.next() < flickerChance * delta) {
-                squares[i] = mulberry.next() * maxOpacity;
-            }
-        }
-    }
-
     watch([canvasRef, inView], ([canvas, inView], _, onCleanup) => {
         if (!canvas || !inView) {
             return;
@@ -156,4 +102,58 @@
             cancelAnimationFrame(frame);
         });
     }, {immediate: true});
+
+    function draw(context: CanvasRenderingContext2D, width: number, height: number, columns: number, rows: number, squares: Float32Array, dpr: number): void {
+        context.clearRect(0, 0, width * dpr, height * dpr);
+
+        const [r, g, b] = unref(rgb);
+
+        for (let i = 0; i < columns; ++i) {
+            for (let j = 0; j < rows; ++j) {
+                const opacity = squares[i * rows + j];
+                context.fillStyle = `rgb(${r} ${g} ${b} / ${opacity})`;
+                context.fillRect(
+                    (i * (size + gap) + width / 2 - (columns / 2 * (size + gap) - gap / 2)) * dpr,
+                    (j * (size + gap) + height / 2 - (rows / 2 * (size + gap) - gap / 2)) * dpr,
+                    size * dpr,
+                    size * dpr
+                );
+            }
+        }
+    }
+
+    function setup(canvas: HTMLCanvasElement) {
+        const width = canvas.clientWidth;
+        const height = canvas.clientHeight;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = width * dpr;
+        canvas.height = height * dpr;
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${height}px`;
+
+        const columns = Math.ceil(width / (size + gap));
+        const rows = Math.ceil(height / (size + gap));
+        const squares = new Float32Array(columns * rows);
+
+        for (let i = 0; i < squares.length; ++i) {
+            squares[i] = mulberry.next() * maxOpacity;
+        }
+
+        return {
+            width,
+            height,
+            columns,
+            rows,
+            squares,
+            dpr
+        };
+    }
+
+    function tick(squares: Float32Array, delta: number): void {
+        for (let i = 0; i < squares.length; ++i) {
+            if (mulberry.next() < flickerChance * delta) {
+                squares[i] = mulberry.next() * maxOpacity;
+            }
+        }
+    }
 </script>

--- a/packages/visuals/src/component/FluxVisualHighlighter.vue
+++ b/packages/visuals/src/component/FluxVisualHighlighter.vue
@@ -48,9 +48,9 @@
         default(): any;
     }>();
 
-    const group = useHighlighterGroupInjection();
-
     const targetRef = useTemplateRef('target');
+
+    const group = useHighlighterGroupInjection();
 
     // Standalone in-view tracking. In a group the parent owns the reveal timing,
     // so no observer is set up at all.
@@ -70,6 +70,39 @@
     let settleTimer: number | undefined;
     let shownTimer: number | undefined;
     let revealed = false;
+
+    // The annotation type is immutable, so any prop change rebuilds it from scratch.
+    watch([effectiveVariant, effectiveColor, effectiveStrokeWidth, effectiveAnimationDuration, effectiveIterations, effectivePadding, effectiveMultiline], () => build());
+
+    // Standalone reveal once the element scrolls into view (whenInView).
+    watch(inView, () => {
+        if (!group) {
+            reveal();
+        }
+    });
+
+    onMounted(() => {
+        const element = targetRef.value;
+
+        if (group && element) {
+            entry = {element, getAnnotation: () => annotation};
+            group.add(entry);
+        }
+
+        build();
+    });
+
+    onBeforeUnmount(() => {
+        if (group && entry) {
+            group.remove(entry);
+            entry = null;
+        }
+
+        window.clearTimeout(shownTimer);
+        stopSettleWatch();
+        annotation?.remove();
+        annotation = null;
+    });
 
     // rough-notation has no completion callback, so shown is emitted after the
     // draw animation's duration, or immediately when it draws without animation.
@@ -176,39 +209,6 @@
         observer.observe(element);
         observer.observe(document.body);
     }
-
-    onMounted(() => {
-        const element = targetRef.value;
-
-        if (group && element) {
-            entry = {element, getAnnotation: () => annotation};
-            group.add(entry);
-        }
-
-        build();
-    });
-
-    // The annotation type is immutable, so any prop change rebuilds it from scratch.
-    watch([effectiveVariant, effectiveColor, effectiveStrokeWidth, effectiveAnimationDuration, effectiveIterations, effectivePadding, effectiveMultiline], () => build());
-
-    // Standalone reveal once the element scrolls into view (whenInView).
-    watch(inView, () => {
-        if (!group) {
-            reveal();
-        }
-    });
-
-    onBeforeUnmount(() => {
-        if (group && entry) {
-            group.remove(entry);
-            entry = null;
-        }
-
-        window.clearTimeout(shownTimer);
-        stopSettleWatch();
-        annotation?.remove();
-        annotation = null;
-    });
 
     defineExpose({
         hide,

--- a/packages/visuals/src/component/FluxVisualNumberFlow.vue
+++ b/packages/visuals/src/component/FluxVisualNumberFlow.vue
@@ -48,6 +48,62 @@
 
     const CUBIC_BEZIER_PATTERN = /^cubic-bezier\(\s*([-\d.]+)\s*,\s*([-\d.]+)\s*,\s*([-\d.]+)\s*,\s*([-\d.]+)\s*\)$/;
 
+    // Fallback for an unrecognised easing value, matching the --swift-out default.
+    const swiftOutEasing = cubicBezier(0.55, 0, 0.1, 1);
+
+    const labelRef = useTemplateRef('label');
+
+    let frame = 0;
+    let current = animateOnMount ? 0 : value;
+
+    // Resolve the easing prop to a plain (t) => number function the tween can
+    // sample: functions pass through, keywords map to the table above and a
+    // cubic-bezier(...) string is parsed into a solver, falling back to swift-out.
+    const easingFunction = computed<NumberFlowEasingFunction>(() => {
+        if (typeof easing === 'function') {
+            return easing;
+        }
+
+        const keyword = EASINGS[easing as NumberFlowEasingKeyword];
+
+        if (keyword) {
+            return keyword;
+        }
+
+        return parseCubicBezier(easing) ?? swiftOutEasing;
+    });
+
+    // Default to whole numbers so a mid-tween value never sprouts stray decimals.
+    // Currency, percentage and fractional displays opt in through `format`.
+    const formatter = computed(() => new Intl.NumberFormat(locale, format ?? {maximumFractionDigits: 0}));
+
+    // Rendered once for SSR / first paint only. The engine owns the span's text
+    // after mount, so this must NOT be reactive - a reactive {{ value }} would make
+    // Vue re-patch the text node every frame and wipe the tween. The accessible
+    // name stays current through the reactive :aria-label binding.
+    const initialText = formatter.value.format(animateOnMount ? 0 : value);
+
+    // Screen readers always read the final, settled value rather than the
+    // intermediate frames streaming past on screen.
+    const accessibleValue = computed(() => formatter.value.format(value));
+
+    // Tween from wherever the display currently sits, so a value that changes
+    // mid-tween keeps rolling smoothly instead of jumping.
+    watch(() => value, next => tween(current, next));
+
+    // Re-render in place when the locale or format changes.
+    watch(formatter, () => render(current));
+
+    onMounted(() => {
+        if (animateOnMount) {
+            tween(0, value);
+        } else {
+            render(value);
+        }
+    });
+
+    onBeforeUnmount(cancel);
+
     // Evaluate a cubic-bezier(x1, y1, x2, y2) timing function in JS. The control
     // points describe x(t) and y(t); for a given progress we need y at the t where
     // x(t) === progress. x is solved with Newton-Raphson and a bisection fallback,
@@ -132,45 +188,6 @@
         return cubicBezier(Number(match[1]), Number(match[2]), Number(match[3]), Number(match[4]));
     }
 
-    // Fallback for an unrecognised easing value, matching the --swift-out default.
-    const swiftOutEasing = cubicBezier(0.55, 0, 0.1, 1);
-
-    // Resolve the easing prop to a plain (t) => number function the tween can
-    // sample: functions pass through, keywords map to the table above and a
-    // cubic-bezier(...) string is parsed into a solver, falling back to swift-out.
-    const easingFunction = computed<NumberFlowEasingFunction>(() => {
-        if (typeof easing === 'function') {
-            return easing;
-        }
-
-        const keyword = EASINGS[easing as NumberFlowEasingKeyword];
-
-        if (keyword) {
-            return keyword;
-        }
-
-        return parseCubicBezier(easing) ?? swiftOutEasing;
-    });
-
-    // Default to whole numbers so a mid-tween value never sprouts stray decimals.
-    // Currency, percentage and fractional displays opt in through `format`.
-    const formatter = computed(() => new Intl.NumberFormat(locale, format ?? {maximumFractionDigits: 0}));
-
-    // Rendered once for SSR / first paint only. The engine owns the span's text
-    // after mount, so this must NOT be reactive - a reactive {{ value }} would make
-    // Vue re-patch the text node every frame and wipe the tween. The accessible
-    // name stays current through the reactive :aria-label binding.
-    const initialText = formatter.value.format(animateOnMount ? 0 : value);
-
-    // Screen readers always read the final, settled value rather than the
-    // intermediate frames streaming past on screen.
-    const accessibleValue = computed(() => formatter.value.format(value));
-
-    const labelRef = useTemplateRef('label');
-
-    let frame = 0;
-    let current = animateOnMount ? 0 : value;
-
     function render(next: number): void {
         current = next;
 
@@ -215,21 +232,4 @@
 
         frame = requestAnimationFrame(step);
     }
-
-    onMounted(() => {
-        if (animateOnMount) {
-            tween(0, value);
-        } else {
-            render(value);
-        }
-    });
-
-    // Tween from wherever the display currently sits, so a value that changes
-    // mid-tween keeps rolling smoothly instead of jumping.
-    watch(() => value, next => tween(current, next));
-
-    // Re-render in place when the locale or format changes.
-    watch(formatter, () => render(current));
-
-    onBeforeUnmount(cancel);
 </script>

--- a/packages/visuals/src/component/FluxVisualSlotText.vue
+++ b/packages/visuals/src/component/FluxVisualSlotText.vue
@@ -82,13 +82,35 @@
     let revertTimeout: number | undefined;
     let restingText: string | undefined;
 
-    const glyph = (char: string): string => char === ' ' ? NBSP : char;
+    watch(() => text, value => set(value));
+
+    onMounted(() => {
+        const element = labelRef.value;
+
+        if (element) {
+            buildSlotText(element, text);
+        }
+    });
+
+    onBeforeUnmount(() => {
+        window.clearTimeout(revertTimeout);
+
+        const element = labelRef.value;
+
+        if (element) {
+            clearSlotText(element, text);
+        }
+    });
+
+    function glyph(char: string): string {
+        return char === ' ' ? NBSP : char;
+    }
 
     // Sweep the hue across the line so the roll lands as a chromatic spectrum.
-    const chromaticColor = (index: number, total: number): string => {
+    function chromaticColor(index: number, total: number): string {
         const t = total <= 1 ? 0 : index / (total - 1);
         return `hsl(${(t * 320) % 360} 92% 60%)`;
-    };
+    }
 
     function baseOptions(): AnimateOptions {
         return {
@@ -429,26 +451,6 @@
             }
         }, revertAfter);
     }
-
-    onMounted(() => {
-        const element = labelRef.value;
-
-        if (element) {
-            buildSlotText(element, text);
-        }
-    });
-
-    watch(() => text, value => set(value));
-
-    onBeforeUnmount(() => {
-        window.clearTimeout(revertTimeout);
-
-        const element = labelRef.value;
-
-        if (element) {
-            clearSlotText(element, text);
-        }
-    });
 
     defineExpose({
         flash,

--- a/packages/visuals/src/component/FluxVisualTextScramble.vue
+++ b/packages/visuals/src/component/FluxVisualTextScramble.vue
@@ -22,6 +22,10 @@
         fixed: boolean;
     };
 
+    const emit = defineEmits<{
+        finished: [];
+    }>();
+
     const {
         text,
         characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
@@ -38,10 +42,6 @@
         readonly stagger?: number;
     }>();
 
-    const emit = defineEmits<{
-        finished: [];
-    }>();
-
     // Rendered once for SSR / first paint only. The engine owns the span's text
     // after mount, so this must NOT be reactive - a reactive {{ text }} would make
     // Vue re-patch the text node every frame and wipe the scramble. The accessible
@@ -52,6 +52,10 @@
 
     let frame = 0;
     let currentText = text;
+
+    watch(() => text, value => set(value));
+
+    onBeforeUnmount(cancel);
 
     function cancel(): void {
         if (frame) {
@@ -156,10 +160,6 @@
 
         scramble(element, currentText, currentText, true);
     }
-
-    watch(() => text, value => set(value));
-
-    onBeforeUnmount(cancel);
 
     defineExpose({
         replay,


### PR DESCRIPTION
Aligns 75 components across the `components`, `application`, `statistics`, `flow` and `visuals` packages with the vue-component-anatomy standard. Purely structural: no runtime behaviour, public API, styling or logic changed.

## What changed

| Rule | Count | Fix |
|------|-------|-----|
| `script-order` | 67 | reorder `<script setup>` to state → composables → computed → watch → lifecycle → functions (moving `watch` above lifecycle hooks, template refs into the state group, computeds out of the function block) |
| `function-vs-arrow` | 15 | top-level named handlers/helpers as `function` declarations instead of arrow consts |
| `macro-order` | 14 | compiler macros in order (`defineOptions → defineEmits → defineModel → defineProps → defineSlots`), `defineExpose` last |
| `v-for-key` | 10 | add a stable `:key` to every `v-for` |
| `template-refs` | 4 | old `ref()` template refs → `useTemplateRef` |
| `block-order` | 3 | `<template>` before `<script setup>` |
| `template-logic` | 1 | extract heavy inline template expression into a computed |
| `import-order` | 1 | style import moved last |
| `prop-typing` | 1 | inline prop field marked `readonly` |
| `emits-model` | 1 | hand-rolled `viewport` prop + `update:viewport` emit → `defineModel` (`FluxFlow`) |

Reordering preserved declare-before-use: no declaration moved below a use, and no `watch`/composable moved above state it reads at setup time.

## Verification

All five packages build clean (`vue-tsc` type-check + `vite build`): components, application, statistics, flow, visuals.

## Scope note

`FluxFormFader` and `FluxFormRangeFader` are intentionally **not** included here — they belong to the in-progress `feat/form-fader` branch and don't exist on `main`. Their anatomy polish rides along with that feature.

https://claude.ai/code/session_014MLZiCR6M4EFkiPKGnXv1N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-way `v-model:viewport` support for flow diagrams, replacing the previous viewport update pattern.
  * Flow nodes and calendar items now maintain more reliable sizing and drag interactions.
  * Application navigation now better synchronizes active views with route changes and menu state.

* **Bug Fixes**
  * Improved list, table, calendar, menu, and chart rendering stability.
  * Data tables now return to the top and clear selection when their items change.
  * Enhanced popup positioning, form synchronization, and interactive component lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->