### PR TITLE
perf: reduce per-instance listeners and hot-path work

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
     "docs": {
       "name": "docs",
       "dependencies": {
-        "@basmilius/common": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
         "@faker-js/faker": "^10.5.0",
         "@flux-ui/application": "workspace:*",
         "@flux-ui/components": "workspace:*",
@@ -30,7 +30,7 @@
         "vue-router": "^5.2.0",
       },
       "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@flux-ui/types": "workspace:*",
         "@types/luxon": "^3.7.2",
         "vite": "^8.1.4",
@@ -46,7 +46,7 @@
         "clsx": "^2.1.1",
       },
       "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",
@@ -65,15 +65,15 @@
       "name": "@flux-ui/components",
       "version": "0.0.0",
       "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
         "imask": "^7.6.1",
       },
       "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@fortawesome/fontawesome-common-types": "^7.3.0",
         "@types/luxon": "^3.7.2",
         "@types/node": "^26.1.1",
@@ -99,7 +99,7 @@
         "clsx": "^2.1.1",
       },
       "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",
@@ -116,8 +116,8 @@
       "name": "@flux-ui/internals",
       "version": "0.0.0",
       "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/types": "workspace:*",
         "lodash-es": "^4.18.1",
       },
@@ -135,15 +135,15 @@
       "name": "@flux-ui/statistics",
       "version": "0.0.0",
       "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/components": "workspace:*",
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
       },
       "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
@@ -177,15 +177,15 @@
       "name": "@flux-ui/visuals",
       "version": "0.0.0",
       "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
         "rough-notation": "^0.5.1",
       },
       "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",
@@ -219,13 +219,13 @@
 
     "@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
-    "@basmilius/common": ["@basmilius/common@3.53.0", "", { "dependencies": { "@basmilius/http-client": "3.53.0", "@basmilius/utils": "3.53.0", "culori": "^4.0.2", "lodash-es": "^4.18.1" }, "peerDependencies": { "pinia": "^4.0.2", "vue": "^3.6.0-beta.17", "vue-router": "^5.2.0" } }, "sha512-7PNI6MUS2Ef637CTchL5Yd37H7nUYU8of0mncTq733/U9s5VRJRzmUtHAglqEGlcg8tIBqq1W04yW3IVw959/w=="],
+    "@basmilius/common": ["@basmilius/common@3.55.0", "", { "dependencies": { "@basmilius/http-client": "3.55.0", "@basmilius/utils": "3.55.0", "culori": "^4.0.2", "lodash-es": "^4.18.1" }, "peerDependencies": { "pinia": "^4.0.2", "vue": "^3.6.0-beta.17", "vue-router": "^5.2.0" } }, "sha512-Z6gcxW929NUPMIcQ5zDzpyxPuHLxrrVh9REHNnkV5iV9T9jkwIi6lAbRD31H3Ds9wWvIvwriyYzQhhsIs25uWw=="],
 
-    "@basmilius/http-client": ["@basmilius/http-client@3.53.0", "", { "dependencies": { "@basmilius/utils": "3.53.0" }, "peerDependencies": { "luxon": "^3.7.2", "vite": ">=5", "vue": "^3.6.0-beta.17" }, "optionalPeers": ["vite"] }, "sha512-0W2ZMsJ14kj5fOjTL5PfGx0UKhmpR0Mz5+eYV1xiqclqxdlwpemX9oY8w0MtqpEmL8YiwoJ0QLpBSnG9BY7RTw=="],
+    "@basmilius/http-client": ["@basmilius/http-client@3.55.0", "", { "dependencies": { "@basmilius/utils": "3.55.0" }, "peerDependencies": { "luxon": "^3.7.2", "vite": ">=5", "vue": "^3.6.0-beta.17" }, "optionalPeers": ["vite"] }, "sha512-Eb2gbnvXmWRrOAFDhN21MXQc0rapORDZ0Bq3XvTXfWbRETvDa6kYb0QiuX8QLDdcwgbqW5Zwxt36d10rphmOoA=="],
 
-    "@basmilius/utils": ["@basmilius/utils@3.53.0", "", { "peerDependencies": { "luxon": "^3.7.2" } }, "sha512-3msuSlsvadMjQJZgUwSPl4/3BkXq/rkAQxKVh2LzVvACTg5zcMNq516VFtKk6W7NjFNQ+bbSTkhFEoky4ZICxw=="],
+    "@basmilius/utils": ["@basmilius/utils@3.55.0", "", { "peerDependencies": { "luxon": "^3.7.2" } }, "sha512-V/UV/GHZ8qelmJ+YWrSDEFnVQcUGJkPihKV5i/V8YlRh4RuSeeTMh6ygsLFjJyUjRxpG8y+0IvxkoMfEv857Tw=="],
 
-    "@basmilius/vite-preset": ["@basmilius/vite-preset@3.53.0", "", { "dependencies": { "@laynezh/vite-plugin-lib-assets": "^2.1.3", "change-case": "^5.4.4", "css-class-generator": "^2.0.0", "lightningcss": "^1.32.0", "vite-css-modules": "^1.16.0", "vite-plugin-dts": "^5.0.3" }, "peerDependencies": { "vite": "^8.1.4" } }, "sha512-vYoN9ZcTuK/mmOfmeZF//XLCVypilVDvMy0V0DEWXEr6Fivm/X/nDD9FxM/gZ7BxFkv1eHxU7xtWmI5HuR/elw=="],
+    "@basmilius/vite-preset": ["@basmilius/vite-preset@3.55.0", "", { "dependencies": { "@laynezh/vite-plugin-lib-assets": "^2.1.3", "change-case": "^5.4.4", "css-class-generator": "^2.0.0", "lightningcss": "^1.32.0", "vite-css-modules": "^1.16.0", "vite-plugin-dts": "^5.0.3" }, "peerDependencies": { "vite": "^8.1.4" } }, "sha512-SHgdAcdlSwwbrzD7qKyxOKT7wI0L572/30epmH9ihBzTBO48I0ulesOi0NL2WKFYAcSzIOWys5NZnEVyypXN4A=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -71,12 +71,10 @@
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
         "imask": "^7.6.1",
-        "lodash-es": "^4.18.1",
       },
       "devDependencies": {
         "@basmilius/vite-preset": "^3.53.0",
         "@fortawesome/fontawesome-common-types": "^7.3.0",
-        "@types/lodash-es": "^4.17.12",
         "@types/luxon": "^3.7.2",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
         "preview": "vitepress preview"
     },
     "dependencies": {
-        "@basmilius/common": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
         "@faker-js/faker": "^10.5.0",
         "@flux-ui/application": "workspace:*",
         "@flux-ui/components": "workspace:*",
@@ -30,7 +30,7 @@
         "vue-router": "^5.2.0"
     },
     "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@flux-ui/types": "workspace:*",
         "@types/luxon": "^3.7.2",
         "vite": "^8.1.4"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -61,7 +61,7 @@
         "vue-router": "^5.2.0"
     },
     "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",

--- a/packages/application/src/component/FluxApplicationTop.vue
+++ b/packages/application/src/component/FluxApplicationTop.vue
@@ -1,5 +1,5 @@
 <template>
-    <header :class="y > 1 ? $style.applicationTopScrolled : $style.applicationTop">
+    <header :class="isScrolled ? $style.applicationTopScrolled : $style.applicationTop">
         <div :class="$style.applicationTopBar">
             <FluxApplicationMenuToggle :class="!showDesktopMenuToggle && $style.applicationTopMenuToggleHidden"/>
 
@@ -53,7 +53,7 @@
     import { useScrollPosition } from '@flux-ui/internals';
     import type { FluxIconName } from '@flux-ui/types';
     import { clsx } from 'clsx';
-    import type { VNode } from 'vue';
+    import { computed, type VNode } from 'vue';
     import { useApplicationInjection } from '../composable';
     import FluxApplicationMenuToggle from './FluxApplicationMenuToggle.vue';
     import $style from '~flux/application/css/component/ApplicationTop.module.scss';
@@ -71,4 +71,6 @@
 
     const {layout, showDesktopMenuToggle} = useApplicationInjection();
     const {y} = useScrollPosition();
+
+    const isScrolled = computed(() => y.value > 1);
 </script>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -51,8 +51,8 @@
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
@@ -64,7 +64,7 @@
         "vue": "^3.6.0-beta.17"
     },
     "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@fortawesome/fontawesome-common-types": "^7.3.0",
         "@types/luxon": "^3.7.2",
         "@types/node": "^26.1.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,8 +56,7 @@
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
-        "imask": "^7.6.1",
-        "lodash-es": "^4.18.1"
+        "imask": "^7.6.1"
     },
     "peerDependencies": {
         "@fortawesome/fontawesome-common-types": "^7.3.0",
@@ -67,7 +66,6 @@
     "devDependencies": {
         "@basmilius/vite-preset": "^3.53.0",
         "@fortawesome/fontawesome-common-types": "^7.3.0",
-        "@types/lodash-es": "^4.17.12",
         "@types/luxon": "^3.7.2",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -94,25 +94,25 @@
                     :aria-rowindex="(page - 1) * perPage + entry.index + 2"
                     :is-clickable="isRowInteractive"
                     :is-hidden="chunk.isCollapsed"
-                    :is-selected="selectionMode ? isItemSelected(entry.item) : false"
+                    :is-selected="rowStates.get(entry.key)?.isSelected"
                     @row-click="(columnIndex, event) => onRowClick(entry.item, columnIndex, event)">
                     <FluxTableCell
                         v-if="selectionMode"
                         :class="$style.tableCellSelection">
                         <FluxFormCheckbox
-                            :model-value="isItemSelected(entry.item)"
+                            :model-value="rowStates.get(entry.key)?.isSelected"
                             @update:model-value="onSelectRow(entry.item)"/>
                     </FluxTableCell>
 
                     <FluxTableCell
                         v-if="hasExpandable"
                         :class="$style.tableCellExpand">
-                        <FluxTableActions v-if="isRowExpandable(entry.item)">
+                        <FluxTableActions v-if="rowStates.get(entry.key)?.isExpandable">
                             <FluxAction
-                                :class="clsx($style.tableExpandToggle, isItemExpanded(entry.item) && $style.isExpanded)"
+                                :class="clsx($style.tableExpandToggle, rowStates.get(entry.key)?.isExpanded && $style.isExpanded)"
                                 icon="angle-right"
-                                :aria-expanded="isItemExpanded(entry.item)"
-                                :aria-label="isItemExpanded(entry.item) ? translate('flux.collapseRow') : translate('flux.expandRow')"
+                                :aria-expanded="rowStates.get(entry.key)?.isExpanded"
+                                :aria-label="rowStates.get(entry.key)?.isExpanded ? translate('flux.collapseRow') : translate('flux.expandRow')"
                                 @click="toggleExpand(entry.item)"/>
                         </FluxTableActions>
                     </FluxTableCell>
@@ -120,13 +120,13 @@
                     <template v-for="(_, name) of slots" :key="name">
                         <slot
                             v-if="!IGNORED_SLOTS.includes(name as string)"
-                            v-bind="{index: entry.index, item: entry.item, items: limitedItems, page, perPage, total, isSelected: isItemSelected(entry.item)}"
+                            v-bind="{index: entry.index, item: entry.item, items: limitedItems, page, perPage, total, isSelected: rowStates.get(entry.key)?.isSelected ?? false}"
                             :name="name"/>
                     </template>
                 </FluxTableRow>
 
                 <FluxTableRow
-                    v-if="hasExpandable && isItemExpanded(entry.item)"
+                    v-if="hasExpandable && rowStates.get(entry.key)?.isExpanded"
                     :is-hidden="chunk.isCollapsed">
                     <FluxTableCell :colspan="columnCount">
                         <template #content>
@@ -419,6 +419,22 @@
 
     const expandedSet = computed<ReadonlySet<SelectionId>>(() => new Set(unref(expanded)));
     const collapsedGroupSet = computed<ReadonlySet<SelectionId>>(() => new Set(unref(collapsedGroups)));
+
+    const rowStates = computed(() => {
+        const states = new Map<SelectionId, { isExpandable: boolean; isExpanded: boolean; isSelected: boolean }>();
+
+        for (const chunk of unref(renderChunks)) {
+            for (const entry of chunk.entries) {
+                states.set(entry.key, {
+                    isExpandable: isRowExpandable(entry.item),
+                    isExpanded: isItemExpanded(entry.item),
+                    isSelected: isItemSelected(entry.item)
+                });
+            }
+        }
+
+        return states;
+    });
 
     const selectedIds = computed<SelectionId[]>(() => Array.from(unref(selectedSet)));
     const selectedCount = computed(() => unref(selectedIds).length);

--- a/packages/components/src/component/FluxFormTimeZonePicker.vue
+++ b/packages/components/src/component/FluxFormTimeZonePicker.vue
@@ -19,12 +19,12 @@
     setup>
     import { isSSR } from '@flux-ui/internals';
     import type { FluxFormInputBaseProps, FluxFormSelectEntry } from '@flux-ui/types';
-    import { upperFirst } from 'lodash-es';
     import { computed, toRef } from 'vue';
     import { useDisabled } from '~flux/components/composable';
     import { useTranslate } from '~flux/components/composable/private';
     import type { FluxTranslation } from '~flux/components/data';
     import { TIME_ZONE_GROUP_ORDER, TIME_ZONES } from '~flux/components/data/timeZones';
+    import { upperFirst } from '~flux/components/util';
     import FluxFormSelect from './FluxFormSelect.vue';
 
     const modelValue = defineModel<string | null>({

--- a/packages/components/src/component/FluxIcon.vue
+++ b/packages/components/src/component/FluxIcon.vue
@@ -4,12 +4,7 @@
         :viewBox.attr="`0 0 ${definition.width} ${definition.height}`"
         :class="clsx(
             $style.fontAwesomeIcon,
-            color === 'gray' && $style.iconGray,
-            color === 'primary' && $style.iconPrimary,
-            color === 'danger' && $style.iconDanger,
-            color === 'info' && $style.iconInfo,
-            color === 'success' && $style.iconSuccess,
-            color === 'warning' && $style.iconWarning
+            color && ICON_COLOR_CLASS[color]
         )"
         :style="{
             fontSize: typeof size === 'number' ? `${size}px` : size,
@@ -54,6 +49,15 @@
         readonly size?: number | string;
         readonly name?: FluxIconName;
     }>();
+
+    const ICON_COLOR_CLASS: Readonly<Record<FluxColor, string>> = Object.freeze({
+        gray: $style.iconGray,
+        primary: $style.iconPrimary,
+        danger: $style.iconDanger,
+        info: $style.iconInfo,
+        success: $style.iconSuccess,
+        warning: $style.iconWarning
+    });
 
     const definition = computed(() => {
         if (!name) {

--- a/packages/components/src/component/FluxSnackbarProvider.vue
+++ b/packages/components/src/component/FluxSnackbarProvider.vue
@@ -9,7 +9,7 @@
         :leave-to-class="$style.snackbarsLeaveTo"
         :move-class="$style.snackbarsMove">
         <FluxSnackbar
-            v-for="snackbar of snackbars.toReversed()"
+            v-for="snackbar of reversedSnackbars"
             :key="snackbar.id"
             :="snackbar"
             is-rendered/>
@@ -19,9 +19,11 @@
 <script
     lang="ts"
     setup>
+    import { computed } from 'vue';
     import { useFluxStore } from '~flux/components/data';
     import FluxSnackbar from './FluxSnackbar.vue';
     import $style from '~flux/components/css/component/Snackbar.module.scss';
 
     const {snackbars} = useFluxStore();
+    const reversedSnackbars = computed(() => snackbars.toReversed());
 </script>

--- a/packages/components/src/component/FluxTable.vue
+++ b/packages/components/src/component/FluxTable.vue
@@ -92,9 +92,10 @@
     lang="ts"
     setup>
     import { animationFrameDebounce, useScrollPosition } from '@flux-ui/internals';
-    import { computed, onMounted, provide, type Ref, ref, shallowReactive, unref, useId, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
+    import { computed, onMounted, onScopeDispose, provide, type Ref, ref, shallowReactive, shallowRef, unref, useId, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
     import { useTableTree } from '~flux/components/composable/private';
     import { type FluxTableColumnDef, FluxTableInjectionKey, type FluxTablePinnedEdges } from '~flux/components/data';
+    import { subscribeToRootFontSize } from '~flux/components/util';
     import FluxPaneBody from './FluxPaneBody.vue';
     import FluxSpinner from './FluxSpinner.vue';
     import FluxTableCell from './FluxTableCell.vue';
@@ -146,8 +147,8 @@
     const footHeight = ref(0);
     const maxScrollLeft = ref(0);
     const fallbackColumnCount = ref(0);
-    const pinnedEdges = ref<FluxTablePinnedEdges>({end: -1, start: -1});
-    const pinnedOffsets = ref(new Map<number, number>());
+    const pinnedEdges = shallowRef<FluxTablePinnedEdges>({end: -1, start: -1});
+    const pinnedOffsets = shallowRef(new Map<number, number>());
     const columnRegistrations = shallowReactive(new Set<ColumnRegistration>());
 
     const {registerTreeNode, treeLines} = useTableTree(bodyRef);
@@ -443,10 +444,10 @@
             observer.observe(foot);
         }
 
-        observer.observe(document.documentElement); // observe font-size changes.
-
         onCleanup(() => observer.disconnect());
     }, {immediate: true});
+
+    onScopeDispose(subscribeToRootFontSize(measure));
 
     // The columns registered during setup only reach the DOM with the next
     // template patch, which lands after ancestors' mounted hooks. Write the

--- a/packages/components/src/component/FluxTableCell.vue
+++ b/packages/components/src/component/FluxTableCell.vue
@@ -62,9 +62,17 @@
 
     const isRaw = computed(() => 'content' in slots);
 
+    const columnIndex = computed(() => {
+        void columns.value;
+
+        const element = cell.value;
+
+        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
+    });
+
     // Spanning cells cover multiple columns, so their column's definition
     // (pinning, alignment, formatting) does not apply to them.
-    const column = computed(() => colspan ? undefined : unref(columns)[getColumnIndex()]);
+    const column = computed(() => colspan ? undefined : unref(columns)[columnIndex.value]);
 
     const effectiveAlign = computed(() => align ?? column.value?.align);
     const effectiveIsNumeric = computed(() => isNumeric || (column.value?.isNumeric ?? false));
@@ -87,11 +95,9 @@
             return false;
         }
 
-        const columnIndex = getColumnIndex();
-
         return pinnedSide.value === 'start'
-            ? columnIndex === pinnedEdges.value.start
-            : columnIndex === pinnedEdges.value.end;
+            ? columnIndex.value === pinnedEdges.value.start
+            : columnIndex.value === pinnedEdges.value.end;
     });
 
     const cellStyle = computed(() => {
@@ -124,7 +130,7 @@
         }
 
         if (pinnedSide.value) {
-            const offset = pinnedOffsets.value.get(getColumnIndex()) ?? 0;
+            const offset = pinnedOffsets.value.get(columnIndex.value) ?? 0;
 
             if (pinnedSide.value === 'start') {
                 style.left = `${offset}px`;
@@ -135,10 +141,4 @@
 
         return style;
     });
-
-    function getColumnIndex(): number {
-        const element = cell.value;
-
-        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
-    }
 </script>

--- a/packages/components/src/component/FluxTableHeader.vue
+++ b/packages/components/src/component/FluxTableHeader.vue
@@ -110,12 +110,21 @@
     const header = useTemplateRef('header');
 
     const {
+        columns,
         pinnedEdges,
         pinnedOffsets,
         registerColumn
     } = useTableInjection();
 
     const translate = useTranslate();
+
+    const columnIndex = computed(() => {
+        void columns.value;
+
+        const element = header.value;
+
+        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
+    });
 
     const pinnedSide = computed<'start' | 'end' | null>(() => {
         if (pinned === true || pinned === 'start') {
@@ -145,11 +154,9 @@
             return false;
         }
 
-        const columnIndex = getColumnIndex();
-
         return pinnedSide.value === 'start'
-            ? columnIndex === pinnedEdges.value.start
-            : columnIndex === pinnedEdges.value.end;
+            ? columnIndex.value === pinnedEdges.value.start
+            : columnIndex.value === pinnedEdges.value.end;
     });
 
     const headerStyle = computed(() => {
@@ -161,7 +168,7 @@
         }
 
         if (pinnedSide.value) {
-            const offset = pinnedOffsets.value.get(getColumnIndex()) ?? 0;
+            const offset = pinnedOffsets.value.get(columnIndex.value) ?? 0;
 
             if (pinnedSide.value === 'start') {
                 style.left = `${offset}px`;
@@ -214,10 +221,4 @@
 
     const unregisterColumn = registerColumn(header, columnDef);
     onUnmounted(unregisterColumn);
-
-    function getColumnIndex(): number {
-        const element = header.value;
-
-        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
-    }
 </script>

--- a/packages/components/src/component/FluxTooltip.vue
+++ b/packages/components/src/component/FluxTooltip.vue
@@ -20,14 +20,12 @@
                 const elm = instance.proxy!.$el;
                 elm.addEventListener('mouseenter', onHover, {passive: true});
                 elm.addEventListener('mouseleave', onLeave, {passive: true});
-                window.addEventListener('scroll', onLeave, {capture: true});
             });
 
             onUnmounted(() => {
                 const elm = instance.proxy!.$el;
                 elm.removeEventListener('mouseenter', onHover);
                 elm.removeEventListener('mouseleave', onLeave);
-                window.removeEventListener('scroll', onLeave, {capture: true});
                 onLeave();
             });
 

--- a/packages/components/src/component/FluxTooltipProvider.vue
+++ b/packages/components/src/component/FluxTooltipProvider.vue
@@ -2,7 +2,7 @@
     import { unrefTemplateElement } from '@flux-ui/internals';
     import { clsx } from 'clsx';
     import { computed, defineComponent, h, provide, ref, unref, watch } from 'vue';
-    import { FluxTooltipInjectionKey, useFluxStore } from '~flux/components/data';
+    import { FluxTooltipInjectionKey, removeTooltip, useFluxStore } from '~flux/components/data';
     import { FluxTooltipTransition } from '~flux/components/transition';
     import $style from '~flux/components/css/component/Tooltip.module.scss';
 
@@ -77,6 +77,26 @@
             if (host && !host.matches(':popover-open')) {
                 host.showPopover();
             }
+        });
+
+        watch(has, (isVisible, _, onCleanup) => {
+            if (!isVisible) {
+                return;
+            }
+
+            function dismiss(): void {
+                const spec = unref(tooltip);
+
+                if (spec) {
+                    removeTooltip(spec.id);
+                }
+            }
+
+            window.addEventListener('scroll', dismiss, {capture: true, passive: true});
+
+            onCleanup(() => {
+                window.removeEventListener('scroll', dismiss, {capture: true});
+            });
         });
 
         return () => h('div', {

--- a/packages/components/src/component/calendar/FluxCalendarTimeGridView.vue
+++ b/packages/components/src/component/calendar/FluxCalendarTimeGridView.vue
@@ -46,7 +46,7 @@
                             <div
                                 :class="$style.timeGridHourLabel"
                                 :style="{height: `${pixelsPerMinute * 60}px`}">
-                                <span :class="$style.timeGridHourLabelText">{{ formatHour(hour) }}</span>
+                                <span :class="$style.timeGridHourLabelText">{{ hourLabels.get(hour) }}</span>
                             </div>
                         </template>
                     </div>
@@ -206,6 +206,29 @@
         return map;
     });
 
+    // Precompute the all-day items per day, depending only on items + viewDates, so drag-hover
+    // state changes (which update resizePreview / dropTargetMinutes) don't refilter every column.
+    const allDayItemsByDay = computed(() => {
+        const map = new Map<string | null, FluxCalendarItemData[]>();
+
+        for (const d of viewDates) {
+            const dStr = d.toSQLDate();
+            map.set(dStr, items.filter(item => item.allDay && item.date.toSQLDate() === dStr));
+        }
+
+        return map;
+    });
+
+    const hourLabels = computed<Map<number, string>>(() => {
+        const map = new Map<number, string>();
+
+        for (const hour of unref(hours)) {
+            map.set(hour, DateTime.fromObject({hour}).toFormat('HH:mm'));
+        }
+
+        return map;
+    });
+
     function isToday(d: DateTime): boolean {
         return d.hasSame(DateTime.now(), 'day');
     }
@@ -222,14 +245,8 @@
         return d.toLocaleString({weekday: 'short', day: 'numeric'});
     }
 
-    function formatHour(hour: number): string {
-        return DateTime.fromObject({hour}).toFormat('HH:mm');
-    }
-
     function getAllDayItems(d: DateTime): FluxCalendarItemData[] {
-        const dStr = d.toSQLDate();
-
-        return items.filter(item => item.allDay && item.date.toSQLDate() === dStr);
+        return unref(allDayItemsByDay).get(d.toSQLDate()) ?? [];
     }
 
     function getTimedItems(d: DateTime): Positioned[] {

--- a/packages/components/src/component/primitive/AnchorPopup.vue
+++ b/packages/components/src/component/primitive/AnchorPopup.vue
@@ -15,6 +15,7 @@
     setup>
     import { useMutationObserver } from '@basmilius/common';
     import { isHtmlElement } from '@basmilius/utils';
+    import { animationFrameDebounce } from '@flux-ui/internals';
     import type { FluxDirection } from '@flux-ui/types';
     import { type ComponentPublicInstance, onMounted, onUnmounted, reactive, ref, unref, useTemplateRef, type VNode, watchEffect } from 'vue';
 
@@ -216,9 +217,7 @@
         reposition();
     }
 
-    function onScroll(): void {
-        reposition();
-    }
+    const onScroll = animationFrameDebounce(reposition);
 
     defineExpose({
         reposition,

--- a/packages/components/src/component/primitive/FilterBadge.vue
+++ b/packages/components/src/component/primitive/FilterBadge.vue
@@ -10,9 +10,8 @@
 <script
     lang="ts"
     setup>
-    import { useLoaded } from '@basmilius/common';
     import type { FluxFilterDefinition, FluxFilterValue } from '@flux-ui/types';
-    import { computed, ref, unref, watch } from 'vue';
+    import { useFilterValueLabel } from '~flux/components/composable/private';
     import FluxBadge from '../FluxBadge.vue';
     import $style from '~flux/components/css/component/Filter.module.scss';
 
@@ -28,25 +27,9 @@
         readonly value: FluxFilterValue;
     }>();
 
-    const {isLoading, loaded} = useLoaded();
-    const getValueLabel = computed(() => loaded(item.getValueLabel));
-
-    const valueLabel = ref<string>();
+    const {isLoading, valueLabel} = useFilterValueLabel(() => item, () => value);
 
     function onClick(evt: MouseEvent): void {
         emit('click', evt);
     }
-
-    watch([() => item, () => value], async ([, nextValue], _prev, onCleanup) => {
-        let cancelled = false;
-        onCleanup(() => {
-            cancelled = true;
-        });
-
-        const nextLabel = await unref(getValueLabel)(nextValue);
-
-        if (!cancelled) {
-            valueLabel.value = nextLabel ?? undefined;
-        }
-    }, {deep: true, immediate: true});
 </script>

--- a/packages/components/src/component/primitive/FilterItem.vue
+++ b/packages/components/src/component/primitive/FilterItem.vue
@@ -13,9 +13,8 @@
 <script
     lang="ts"
     setup>
-    import { useLoaded } from '@basmilius/common';
     import type { FluxFilterDefinition, FluxFilterValue } from '@flux-ui/types';
-    import { computed, ref, unref, watch } from 'vue';
+    import { useFilterValueLabel } from '~flux/components/composable/private';
     import FluxMenuItem from '../FluxMenuItem.vue';
 
     const emit = defineEmits<{
@@ -31,25 +30,9 @@
         readonly disabled?: boolean;
     }>();
 
-    const {isLoading, loaded} = useLoaded();
-    const getValueLabel = computed(() => loaded(item.getValueLabel));
-
-    const valueLabel = ref<string>();
+    const {isLoading, valueLabel} = useFilterValueLabel(() => item, () => value);
 
     function onClick(evt: MouseEvent): void {
         emit('click', evt);
     }
-
-    watch([() => item, () => value], async ([, nextValue], _prev, onCleanup) => {
-        let cancelled = false;
-        onCleanup(() => {
-            cancelled = true;
-        });
-
-        const nextLabel = await unref(getValueLabel)(nextValue);
-
-        if (!cancelled) {
-            valueLabel.value = nextLabel ?? undefined;
-        }
-    }, {deep: true, immediate: true});
 </script>

--- a/packages/components/src/composable/private/index.ts
+++ b/packages/components/src/composable/private/index.ts
@@ -13,4 +13,5 @@ export { default as useTranslate } from './useTranslate';
 export { FLUX_COLORS } from './useTreeView';
 export { useCommandPalette, type CommandPaletteGroup, type CommandPaletteResultItem } from './useCommandPalette';
 export { useFilterOptionMulti, useFilterOptionSingle, type FilterOptionMulti, type FilterOptionSingle } from './useFilterOption';
+export { useFilterValueLabel } from './useFilterValueLabel';
 export { flattenAll, flattenVisible, getLevelColor, INITIAL_HIGHLIGHTED_INDEX, useTreeView, type TreeBaseOption, type TreeFlatNode } from './useTreeView';

--- a/packages/components/src/composable/private/useCommandPalette.ts
+++ b/packages/components/src/composable/private/useCommandPalette.ts
@@ -1,6 +1,6 @@
 import { useDebouncedRef } from '@basmilius/common';
 import type { FluxCommandSource, FluxCommandSourceItem, FluxCommandSubAction } from '@flux-ui/types';
-import { computed, nextTick, ref, unref, watch, type Ref } from 'vue';
+import { computed, nextTick, ref, shallowRef, unref, watch, type Ref } from 'vue';
 
 export type CommandPaletteResultItem = {
     readonly globalIndex: number;
@@ -46,7 +46,7 @@ export function useCommandPalette(params: {
     const isLoading = ref(false);
     const isTransitioningBack = ref(false);
     const savedState = ref<{ readonly search: string; readonly highlightedIndex: number; } | null>(null);
-    const asyncResults = ref<Map<string, FluxCommandSourceItem[]>>(new Map());
+    const asyncResults = shallowRef<Map<string, FluxCommandSourceItem[]>>(new Map());
     const debouncedSearch = useDebouncedRef(search, 300) as unknown as Ref<string>;
     let fetchGeneration = 0;
 

--- a/packages/components/src/composable/private/useFilterValueLabel.ts
+++ b/packages/components/src/composable/private/useFilterValueLabel.ts
@@ -1,0 +1,31 @@
+import { useLoaded } from '@basmilius/common';
+import type { FluxFilterDefinition, FluxFilterValue } from '@flux-ui/types';
+import { computed, ref, unref, watch, type ComputedRef, type Ref } from 'vue';
+
+export function useFilterValueLabel(
+    getItem: () => FluxFilterDefinition,
+    getValue: () => FluxFilterValue
+): {
+    readonly isLoading: ComputedRef<boolean>;
+    readonly valueLabel: Ref<string | undefined>;
+} {
+    const {isLoading, loaded} = useLoaded();
+    const getValueLabel = computed(() => loaded(getItem().getValueLabel));
+
+    const valueLabel = ref<string>();
+
+    watch([getItem, getValue], async ([, nextValue], _prev, onCleanup) => {
+        let cancelled = false;
+        onCleanup(() => {
+            cancelled = true;
+        });
+
+        const nextLabel = await unref(getValueLabel)(nextValue);
+
+        if (!cancelled) {
+            valueLabel.value = nextLabel ?? undefined;
+        }
+    }, {deep: true, immediate: true});
+
+    return {isLoading, valueLabel};
+}

--- a/packages/components/src/composable/private/useTableTree.ts
+++ b/packages/components/src/composable/private/useTableTree.ts
@@ -35,12 +35,27 @@ export function useTableTree(container: Readonly<Ref<HTMLElement | null>>) {
         const registration: TreeNodeRegistration = {element, level};
 
         registrations.add(registration);
-        nextTick(measure);
+        scheduleMeasure();
 
         return () => {
             registrations.delete(registration);
-            nextTick(measure);
+            scheduleMeasure();
         };
+    }
+
+    let scheduled = false;
+
+    function scheduleMeasure(): void {
+        if (scheduled) {
+            return;
+        }
+
+        scheduled = true;
+
+        nextTick(() => {
+            measure();
+            scheduled = false;
+        });
     }
 
     function measure(): void {

--- a/packages/components/src/composable/private/useTableTree.ts
+++ b/packages/components/src/composable/private/useTableTree.ts
@@ -116,7 +116,7 @@ export function useTableTree(container: Readonly<Ref<HTMLElement | null>>) {
             observer.observe(container.value);
         }
 
-        nextTick(measure);
+        scheduleMeasure();
     });
 
     onUnmounted(() => observer?.disconnect());

--- a/packages/components/src/composable/useBreakpoints.ts
+++ b/packages/components/src/composable/useBreakpoints.ts
@@ -10,38 +10,45 @@ const BREAKPOINTS = {
 
 type Breakpoint = keyof typeof BREAKPOINTS;
 
-export default function () {
-    const currentBreakpoint = ref<Breakpoint | null>(null);
-    const breakpointRefs = Object.fromEntries(
-        Object.keys(BREAKPOINTS).map((key) => [key, ref(false)])
-    ) as Record<Breakpoint, Ref<boolean>>;
+const currentBreakpoint = ref<Breakpoint | null>(null);
+const breakpointRefs = Object.fromEntries(
+    Object.keys(BREAKPOINTS).map((key) => [key, ref(false)])
+) as Record<Breakpoint, Ref<boolean>>;
 
-    const updateBreakpoints = () => {
-        const width = window.innerWidth;
-        let activeBreakpoint: Breakpoint | null = null;
+let listenerCount = 0;
 
-        for (const [key, value] of Object.entries(BREAKPOINTS) as [
-            Breakpoint,
-            number
-        ][]) {
-            const isActive = width >= value;
-            breakpointRefs[key].value = isActive;
+function updateBreakpoints(): void {
+    const width = window.innerWidth;
+    let activeBreakpoint: Breakpoint | null = null;
 
-            if (isActive) {
-                activeBreakpoint = key;
-            }
+    for (const [key, value] of Object.entries(BREAKPOINTS) as [
+        Breakpoint,
+        number
+    ][]) {
+        const isActive = width >= value;
+        breakpointRefs[key].value = isActive;
+
+        if (isActive) {
+            activeBreakpoint = key;
         }
+    }
 
-        currentBreakpoint.value = activeBreakpoint;
-    };
+    currentBreakpoint.value = activeBreakpoint;
+}
 
+export default function () {
     onMounted(() => {
         updateBreakpoints();
-        window.addEventListener('resize', updateBreakpoints, {passive: true});
+
+        if (++listenerCount === 1) {
+            window.addEventListener('resize', updateBreakpoints, {passive: true});
+        }
     });
 
     onUnmounted(() => {
-        window.removeEventListener('resize', updateBreakpoints);
+        if (--listenerCount === 0) {
+            window.removeEventListener('resize', updateBreakpoints);
+        }
     });
 
     return {

--- a/packages/components/src/data/store.ts
+++ b/packages/components/src/data/store.ts
@@ -68,6 +68,9 @@ const state = reactive<FluxState>({
 let nextDialogId: number = 0;
 let nextId: number = 0;
 
+const inertMain = computed(() => state.dialogs.length > 0);
+const tooltip = computed(() => state.tooltips[state.tooltips.length - 1] || null);
+
 export function addAlert(spec: Omit<FluxAlertObject, 'id'>): number {
     const id = ++nextId;
 
@@ -334,9 +337,6 @@ export async function showSnackbar({duration, ...spec}: Omit<FluxSnackbarObject,
 }
 
 export function useFluxStore(): FluxStore {
-    const inertMain = computed(() => state.dialogs.length > 0);
-    const tooltip = computed(() => state.tooltips[state.tooltips.length - 1] || null);
-
     return {
         get dialogs() {
             return state.dialogs;

--- a/packages/components/src/util/index.ts
+++ b/packages/components/src/util/index.ts
@@ -2,4 +2,6 @@ export { default as createDialogRenderer, FluxDialogInjectionKey, type FluxDialo
 export { default as createLabelForDateRange } from './createLabelForDateRange';
 export { default as defineFilter, type FluxFilterDefinitionFactory } from './defineFilter';
 export { generateMultiOptionsLabel, isFluxFilterOptionHeader, isFluxFilterOptionItem, isResettable, pickFilterCommon } from './filter';
+export { subscribeToRootFontSize } from './rootFontSizeObserver';
 export { default as sanitizeUrl } from './sanitizeUrl';
+export { default as upperFirst } from './upperFirst';

--- a/packages/components/src/util/rootFontSizeObserver.ts
+++ b/packages/components/src/util/rootFontSizeObserver.ts
@@ -1,0 +1,31 @@
+const callbacks = new Set<() => void>();
+
+let observer: ResizeObserver | null = null;
+
+export function subscribeToRootFontSize(callback: () => void): () => void {
+    if (typeof ResizeObserver === 'undefined') {
+        return () => {
+        };
+    }
+
+    callbacks.add(callback);
+
+    if (!observer) {
+        observer = new ResizeObserver(() => {
+            for (const subscriber of callbacks) {
+                subscriber();
+            }
+        });
+
+        observer.observe(document.documentElement);
+    }
+
+    return () => {
+        callbacks.delete(callback);
+
+        if (callbacks.size === 0 && observer) {
+            observer.disconnect();
+            observer = null;
+        }
+    };
+}

--- a/packages/components/src/util/upperFirst.ts
+++ b/packages/components/src/util/upperFirst.ts
@@ -1,0 +1,3 @@
+export default function (value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig(({mode}) => ({
             experimental: {
                 lazyBarrel: true
             },
-            external: ['@flux-ui/visuals', 'luxon', 'vite', 'vue'],
+            external: ['luxon', 'vite', 'vue'],
             output: {
                 assetFileNames: assetInfo => {
                     if (assetInfo.name?.endsWith('.css')) {

--- a/packages/flow/package.json
+++ b/packages/flow/package.json
@@ -56,7 +56,7 @@
         "vue": "^3.6.0-beta.17"
     },
     "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -58,8 +58,8 @@
         }
     },
     "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/types": "workspace:*",
         "lodash-es": "^4.18.1"
     },

--- a/packages/statistics/package.json
+++ b/packages/statistics/package.json
@@ -48,8 +48,8 @@
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/components": "workspace:*",
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
@@ -62,7 +62,7 @@
         "vue-i18n": "^11.4.6"
     },
     "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/statistics/src/composable/useChartLegend.ts
+++ b/packages/statistics/src/composable/useChartLegend.ts
@@ -1,5 +1,5 @@
 import type { FluxIconName } from '@flux-ui/types';
-import { ref, type InjectionKey, type Ref } from 'vue';
+import { ref, shallowRef, type InjectionKey, type Ref } from 'vue';
 
 export interface ChartLegendItem {
     readonly color?: string;
@@ -18,7 +18,7 @@ export const FluxStatisticsChartLegendInjectionKey: InjectionKey<ChartLegendCont
 
 export function createChartLegendContext(): ChartLegendContext {
     return {
-        items: ref<readonly ChartLegendItem[]>([]),
+        items: shallowRef<readonly ChartLegendItem[]>([]),
         hoveredIndex: ref<number | null>(null)
     };
 }

--- a/packages/statistics/src/composable/useECharts.ts
+++ b/packages/statistics/src/composable/useECharts.ts
@@ -41,7 +41,7 @@ export function useECharts(
         chartInstance.value = null;
     });
 
-    useResizeObserver(target as any, () => {
+    useResizeObserver(target, () => {
         if (pendingResize !== null) {
             return;
         }

--- a/packages/statistics/src/util/colors.ts
+++ b/packages/statistics/src/util/colors.ts
@@ -15,6 +15,18 @@ export function useCssVarVersion() {
     return themeVersion;
 }
 
+function resolveWithStyle(input: string, style: CSSStyleDeclaration): string {
+    return input.replace(CSS_VAR_PATTERN, (match, name: string, fallback?: string) => {
+        const value = style.getPropertyValue(name).trim();
+
+        if (value) {
+            return value;
+        }
+
+        return fallback ? resolveWithStyle(fallback.trim(), style) : match;
+    });
+}
+
 export function resolveCssVar(input: string, root?: HTMLElement): string {
     if (typeof document === 'undefined' || !input.includes('var(')) {
         return input;
@@ -22,15 +34,7 @@ export function resolveCssVar(input: string, root?: HTMLElement): string {
 
     const target = root ?? document.documentElement;
 
-    return input.replace(CSS_VAR_PATTERN, (match, name: string, fallback?: string) => {
-        const value = getComputedStyle(target).getPropertyValue(name).trim();
-
-        if (value) {
-            return value;
-        }
-
-        return fallback ? resolveCssVar(fallback.trim(), target) : match;
-    });
+    return resolveWithStyle(input, getComputedStyle(target));
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -42,9 +46,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     return proto === Object.prototype || proto === null;
 }
 
-export function deepResolveCssVars<T>(value: T, root?: HTMLElement): T {
+function deepResolveWithStyle<T>(value: T, style: CSSStyleDeclaration): T {
     if (typeof value === 'string') {
-        return (value.includes('var(') ? resolveCssVar(value, root) : value) as T;
+        return (value.includes('var(') ? resolveWithStyle(value, style) : value) as T;
     }
 
     if (Array.isArray(value)) {
@@ -52,7 +56,7 @@ export function deepResolveCssVars<T>(value: T, root?: HTMLElement): T {
         const out: unknown[] = new Array(value.length);
 
         for (let i = 0; i < value.length; i++) {
-            const resolved = deepResolveCssVars(value[i], root);
+            const resolved = deepResolveWithStyle(value[i], style);
 
             if (resolved !== value[i]) {
                 changed = true;
@@ -73,7 +77,7 @@ export function deepResolveCssVars<T>(value: T, root?: HTMLElement): T {
 
     for (const key of Object.keys(value)) {
         const original = value[key];
-        const resolved = deepResolveCssVars(original, root);
+        const resolved = deepResolveWithStyle(original, style);
 
         if (resolved !== original) {
             changed = true;
@@ -83,4 +87,14 @@ export function deepResolveCssVars<T>(value: T, root?: HTMLElement): T {
     }
 
     return (changed ? out : value) as T;
+}
+
+export function deepResolveCssVars<T>(value: T, root?: HTMLElement): T {
+    if (typeof document === 'undefined') {
+        return value;
+    }
+
+    const target = root ?? document.documentElement;
+
+    return deepResolveWithStyle(value, getComputedStyle(target));
 }

--- a/packages/visuals/package.json
+++ b/packages/visuals/package.json
@@ -48,8 +48,8 @@
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "dependencies": {
-        "@basmilius/common": "^3.53.0",
-        "@basmilius/utils": "^3.53.0",
+        "@basmilius/common": "^3.55.0",
+        "@basmilius/utils": "^3.55.0",
         "@flux-ui/internals": "workspace:*",
         "@flux-ui/types": "workspace:*",
         "clsx": "^2.1.1",
@@ -59,7 +59,7 @@
         "vue": "^3.6.0-beta.17"
     },
     "devDependencies": {
-        "@basmilius/vite-preset": "^3.53.0",
+        "@basmilius/vite-preset": "^3.55.0",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",


### PR DESCRIPTION
## Summary

Optimization pass across the monorepo focused on runtime performance with a strictly backwards-compatible public API (props/emits/slots/exposes/exports unchanged, rendered DOM identical).

### components (86a16548)
- Tooltips: replaced per-instance, always-active, non-passive capture `scroll` listeners on `window` with a single provider-owned listener that is only active while a tooltip is visible.
- Popups (`AnchorPopup`, used by selects/menus/flyouts/tour): rAF-debounced scroll repositioning; exposed `reposition`/`resize` stay synchronous.
- Tables: cached column indexes (was a sibling `indexOf` inside computeds, O(rows × cols²)), precomputed per-row selection/expansion state, one shared root font-size `ResizeObserver` instead of one per table, `shallowRef` for wholesale-replaced pinned maps, coalesced tree measurements (O(N²) → O(N) rect reads on bulk mount).
- Calendar: precomputed all-day items and hour labels; no longer refilters per `dragover`.
- `useBreakpoints`: module-scope singleton state behind a ref-counted resize listener (~50 consumers shared one listener), identical API and SSR behavior.
- Misc: extracted `useFilterValueLabel` (deduped identical script blocks), static icon color lookup, hoisted store computeds, `shallowRef` for command palette results, dropped `lodash-es` for a local `upperFirst`, removed dead `@flux-ui/visuals` external.

### statistics / application (41ec20de)
- `getComputedStyle` once per CSS-var resolve pass instead of per variable on every chart update.
- `shallowRef` for wholesale-replaced chart legend items.
- Application header derives an `isScrolled` computed instead of binding on the live scroll position (re-renders only when crossing the threshold).

### dependencies (783ccee5)
- Bumped `@basmilius/*` to 3.55.0; `useResizeObserver`/`useMutationObserver` are shared observers there now, so charts, meters, panes, tab bars and segmented controls automatically share observer instances.

## Verification

No test suite exists in this repo, so:
- `vue-tsc` + `vite build` green for components, statistics, application, internals; VitePress docs build green.
- All 336 rendered docs pages were diffed against a pre-change golden baseline (with build hashes normalized): zero structural DOM differences; the only diffs were faker-generated demo content and build timestamps.
- Bundle size: CSS byte-identical; JS +0.3% gzip (singleton/precompute code), the wins are runtime work per frame and per interaction.

Deliberately skipped after analysis (documented with reasons): wrapper flattening (zero DOM win), `v-memo` on table rows (user slots have non-enumerable deps), button variant factory (would degrade emitted `.d.ts`), tree flatten caching (breaks reactivity tracking), removing `deep: true` filter watchers (breaks externally-mutating consumers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter controls now provide consistent value labels and loading states.
  * Tooltips automatically dismiss when the page is scrolled.
* **Bug Fixes**
  * Improved header styling transitions when scrolling.
  * Enhanced table pinning, expansion, selection, and layout updates.
  * Improved calendar rendering and time-zone label handling.
  * CSS variable resolution now works more reliably across complex chart configurations.
* **Performance**
  * Smoother scrolling, resizing, chart updates, and large data-table rendering.
  * Reduced unnecessary recalculations across tables, calendars, and responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->