### PR TITLE
feat(icon): opt-in Font Awesome webfont rendering

### DIFF
--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -35,7 +35,7 @@ props:
 
 # Icon
 
-This component displays a single customizable Font Awesome icon, rendered as SVG by default. It is commonly used in various Flux components, including [Buttons](./button), and can be easily styled with CSS. It can also render icons with the Font Awesome webfont, see [Font Awesome](../guide/introduction/font-awesome#using-the-icon-font).
+This component displays a single customizable Font Awesome icon, rendered as SVG by default. It is commonly used in various Flux components, including [Buttons](./button), and can be easily styled with CSS. It can also render icons with the Font Awesome webfont. See [Font Awesome](../guide/introduction/font-awesome#using-the-icon-font).
 
 Please refer to [Font Awesome](../guide/introduction/font-awesome) to read more about the usage of icons.
 

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -22,6 +22,11 @@ props:
         type: [ number, string ]
         optional: true
 
+    -   name: icon-style
+        description: Overrides the Font Awesome family/style for this icon in font mode (for example brands). Ignored in the default SVG mode.
+        type: FluxIconStyle
+        optional: true
+
     -   name: aria-label
         description: An accessible label for the icon. When omitted, the icon is hidden from assistive technology.
         type: string
@@ -30,7 +35,7 @@ props:
 
 # Icon
 
-This component displays a single customizable Font Awesome icon, rendered as SVG. It is commonly used in various Flux components, including [Buttons](./button), and can be easily styled with CSS.
+This component displays a single customizable Font Awesome icon, rendered as SVG by default. It is commonly used in various Flux components, including [Buttons](./button), and can be easily styled with CSS. It can also render icons with the Font Awesome webfont, see [Font Awesome](../guide/introduction/font-awesome#using-the-icon-font).
 
 Please refer to [Font Awesome](../guide/introduction/font-awesome) to read more about the usage of icons.
 

--- a/docs/guide/introduction/font-awesome.md
+++ b/docs/guide/introduction/font-awesome.md
@@ -8,7 +8,7 @@ Flux uses [Font Awesome](https://fontawesome.com) as its icon library, giving yo
 
 ## Register icons
 
-Icons must be registered before use so they are available throughout your application. Import the icons you need from [Font Awesome](https://fontawesome.com) and register them with the `fluxRegisterIcons` function.
+Icons must be registered before use so they are available throughout your application. Import the icons you need from [Font Awesome](https://fontawesome.com) and register them with the `configureIcons` function.
 
 ::: code-group
 
@@ -20,10 +20,10 @@ export {
 ```
 
 ```ts [register.ts]
-import { fluxRegisterIcons  } from '@flux-ui/components';
+import { configureIcons } from '@flux-ui/components';
 import * as icons from './icons.ts';
 
-fluxRegisterIcons(icons);
+configureIcons({icons});
 ```
 
 ```vue [Page.vue]
@@ -41,6 +41,90 @@ fluxRegisterIcons(icons);
 ```
 
 :::
+
+> The standalone `fluxRegisterIcons(icons)` function still works but is deprecated in favor of `configureIcons({icons})`.
+
+## Using the icon font
+
+Instead of registering SVG icons, you can render icons with a Font Awesome webfont. Load the font yourself, bind its `font-family` to the style class Flux emits, then switch Flux to font mode with `configureIcons`. Icons keep being used the same way through the `name` prop.
+
+In font mode `<FluxIcon name="user"/>` renders the icon name as the element's text and relies on the font's ligatures to turn it into the glyph:
+
+```html
+<i class="fa-regular">user</i>
+```
+
+::: code-group
+
+```ts [main.ts]
+import { configureIcons } from '@flux-ui/components';
+
+configureIcons({
+    renderMode: 'font',
+    defaultStyle: 'regular'
+});
+```
+
+```css [fonts.css]
+@font-face {
+    font-family: font-awesome;
+    src: url(...);
+}
+
+/* Bind the style class Flux emits to the loaded font. */
+.fa-regular {
+    font-family: font-awesome;
+    font-weight: 400;
+}
+```
+
+```vue [Page.vue]
+<template>
+    <FluxIcon name="circle-check"/>
+</template>
+
+<script
+    lang="ts"
+    setup>
+    import { FluxIcon } from '@flux-ui/components';
+</script>
+```
+
+:::
+
+Because Font Awesome glyphs draw with `currentColor`, the `color` and `size` props behave exactly as they do in SVG mode. The internal Flux icons were designed against the `regular` family, so `defaultStyle: 'regular'` matches the default SVG look most closely.
+
+### Choosing the style
+
+Flux emits one style class per icon (`fa-solid`, `fa-regular`, `fa-light`, `fa-thin`, `fa-duotone`, `fa-brands`) that you bind to a `font-family`. `FluxIconName` only carries the name, so the style is resolved in this order:
+
+1. The `icon-style` prop on the icon.
+2. A per-name entry in `styleOverrides`.
+3. The global `defaultStyle`.
+4. `solid` as a fallback.
+
+```ts
+configureIcons({
+    renderMode: 'font',
+    defaultStyle: 'light',
+    styleOverrides: {
+        github: 'brands'
+    }
+});
+```
+
+```vue
+<FluxIcon name="github" icon-style="brands"/>
+```
+
+### Duotone
+
+Font Awesome draws a duotone icon as two stacked layers, so in `duotone` mode Flux renders the primary shape over a dimmed secondary one, both from a single `color`. Bind `.fa-duotone` to the duotone font like any other style; tune the secondary tone with the `--fa-secondary-opacity` custom property (default `.2`, matching the SVG rendering).
+
+### Notes
+
+- Font mode does not register any SVG data, so chart icons in `@flux-ui/statistics` still require SVG registration through `configureIcons({icons})`.
+- The font must provide ligatures for the icon names; otherwise the bare name stays visible as text.
 
 ## Required icons
 

--- a/packages/components/src/component/FluxIcon.vue
+++ b/packages/components/src/component/FluxIcon.vue
@@ -1,6 +1,6 @@
 <template>
     <svg
-        v-if="definition"
+        v-if="renderMode === 'svg' && definition"
         :viewBox.attr="`0 0 ${definition.width} ${definition.height}`"
         :class="clsx(
             $style.fontAwesomeIcon,
@@ -23,6 +23,21 @@
     </svg>
 
     <i
+        v-else-if="renderMode === 'font' && name"
+        :class="clsx(
+            $style.iconFont,
+            FONT_STYLE_CLASS[resolvedStyle],
+            color && ICON_COLOR_CLASS[color]
+        )"
+        :style="{
+            fontSize: typeof size === 'number' ? `${size}px` : size
+        }"
+        :role="ariaLabel ? 'img' : undefined"
+        :aria-hidden="ariaLabel ? undefined : true"
+        :aria-label="ariaLabel"
+        @click="onClick"><template v-if="resolvedStyle === 'duotone'"><span :class="$style.iconFontSecondary">{{ `${name}##` }}</span><span :class="$style.iconFontPrimary">{{ `${name}#` }}</span></template><template v-else>{{ name }}</template></i>
+
+    <i
         v-else
         :class="$style.icon"/>
 </template>
@@ -31,10 +46,10 @@
     lang="ts"
     setup>
     import { warn } from '@flux-ui/internals';
-    import type { FluxColor, FluxIconName } from '@flux-ui/types';
+    import type { FluxColor, FluxIconName, FluxIconStyle } from '@flux-ui/types';
     import { clsx } from 'clsx';
     import { computed } from 'vue';
-    import { iconRegistry } from '~flux/components/data';
+    import { iconConfig, iconRegistry } from '~flux/components/data';
     import $style from '~flux/components/css/component/Icon.module.scss';
 
     const emit = defineEmits<{
@@ -42,10 +57,12 @@
     }>();
 
     const {
+        iconStyle,
         name
     } = defineProps<{
         readonly ariaLabel?: string;
         readonly color?: FluxColor;
+        readonly iconStyle?: FluxIconStyle;
         readonly size?: number | string;
         readonly name?: FluxIconName;
     }>();
@@ -58,6 +75,19 @@
         success: $style.iconSuccess,
         warning: $style.iconWarning
     });
+
+    const FONT_STYLE_CLASS: Readonly<Record<FluxIconStyle, string>> = Object.freeze({
+        solid: 'fa-solid',
+        regular: 'fa-regular',
+        light: 'fa-light',
+        thin: 'fa-thin',
+        duotone: 'fa-duotone',
+        brands: 'fa-brands'
+    });
+
+    const renderMode = computed(() => iconConfig.renderMode);
+
+    const resolvedStyle = computed(() => iconStyle ?? (name && iconConfig.styleOverrides[name]) ?? iconConfig.defaultStyle);
 
     const definition = computed(() => {
         if (!name) {

--- a/packages/components/src/css/component/Icon.module.scss
+++ b/packages/components/src/css/component/Icon.module.scss
@@ -18,6 +18,30 @@
         }
     }
 
+    .iconFont {
+        display: inline-grid;
+        height: 1em;
+        flex-shrink: 0;
+        place-items: center;
+        font-size: 20px;
+        font-style: normal;
+        font-variant-ligatures: normal;
+        line-height: 1;
+        white-space: nowrap;
+    }
+
+    // A duotone glyph is drawn as two stacked layers: the primary shape over the
+    // dimmed secondary. Both sit in the same grid cell so they overlap exactly.
+    .iconFontPrimary,
+    .iconFontSecondary {
+        grid-area: 1 / 1;
+    }
+
+    .iconFontSecondary {
+        // Match the SVG duotone rendering, which dims the secondary path to .2.
+        opacity: var(--fa-secondary-opacity, .2);
+    }
+
     .iconBoxed {
         composes: basePane from './base/Pane.module.scss';
 

--- a/packages/components/src/data/iconRegistry.ts
+++ b/packages/components/src/data/iconRegistry.ts
@@ -1,13 +1,60 @@
-import type { FluxIconName } from '@flux-ui/types';
+import type { FluxIconName, FluxIconStyle } from '@flux-ui/types';
 import type { IconDefinition, IconPathData } from '@fortawesome/fontawesome-common-types';
+import { reactive } from 'vue';
 
 type Icon = [number, number, string[], string, IconPathData];
 type IconRegistry = Partial<{ [key in FluxIconName]: Icon; }>;
 type Icons = Record<string, IconDefinition>;
 
+type IconRenderMode = 'svg' | 'font';
+
+type IconConfig = {
+    renderMode: IconRenderMode;
+    defaultStyle: FluxIconStyle;
+    styleOverrides: Partial<Record<FluxIconName, FluxIconStyle>>;
+};
+
+type ConfigureIconsOptions = {
+    readonly renderMode?: IconRenderMode;
+    readonly defaultStyle?: FluxIconStyle;
+    readonly styleOverrides?: Partial<Record<FluxIconName, FluxIconStyle>>;
+    readonly icons?: Icons | readonly IconDefinition[];
+};
+
 export let iconRegistry: IconRegistry = {};
 
+export const iconConfig: IconConfig = reactive({
+    renderMode: 'svg',
+    defaultStyle: 'solid',
+    styleOverrides: {}
+});
+
+export function configureIcons(options: ConfigureIconsOptions): void {
+    if (options.renderMode) {
+        iconConfig.renderMode = options.renderMode;
+    }
+
+    if (options.defaultStyle) {
+        iconConfig.defaultStyle = options.defaultStyle;
+    }
+
+    if (options.styleOverrides) {
+        Object.assign(iconConfig.styleOverrides, options.styleOverrides);
+    }
+
+    if (options.icons) {
+        registerIcons(options.icons);
+    }
+}
+
+/**
+ * @deprecated Use {@link configureIcons} instead: `configureIcons({icons})`.
+ */
 export function fluxRegisterIcons(icons: Icons | readonly IconDefinition[]): void {
+    registerIcons(icons);
+}
+
+function registerIcons(icons: Icons | readonly IconDefinition[]): void {
     iconRegistry = Object.values(icons).reduce((registry: IconRegistry, definition: IconDefinition) => {
         if (!definition) {
             return registry;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,7 +5,9 @@ export * from './composable';
 export * from './transition';
 
 export {
+    configureIcons,
     fluxRegisterIcons,
+    iconConfig,
     iconRegistry,
     isFluxFormSelectGroup,
     isFluxFormSelectOption,

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -2,6 +2,14 @@ import type { IconName as FontAwesome } from '@fortawesome/fontawesome-common-ty
 
 export type FluxIconName = FontAwesome;
 
+export type FluxIconStyle =
+    | 'solid'
+    | 'regular'
+    | 'light'
+    | 'thin'
+    | 'duotone'
+    | 'brands';
+
 export type FluxAlignment =
     | 'start'
     | 'center'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,7 @@ export type {
     FluxDirection,
     FluxFlexWrap,
     FluxIconName,
+    FluxIconStyle,
     FluxInputMask,
     FluxInputType,
     FluxJustify,


### PR DESCRIPTION
## Summary

Adds an opt-in font render mode to `FluxIcon`, alongside the existing SVG mode, so consumers can render icons from a loaded Font Awesome webfont instead of registering SVG path data.

- New `configureIcons({ renderMode, defaultStyle, styleOverrides, icons })` entry point that unifies icon configuration and registration.
- `renderMode: 'font'` renders an `<i>` with the icon name as text and relies on the webfont's ligatures; the consumer binds `.fa-{style}` to a `font-family`.
- Duotone renders as two stacked layers (`name#` primary over `name##` secondary) so it works in browsers without OpenType-SVG color support (e.g. Chrome). The secondary layer is dimmed to `.2`, matching the SVG rendering, and is tunable via `--fa-secondary-opacity`.
- Optional per-instance `iconStyle` prop and a new `FluxIconStyle` type.
- Docs updated (Font Awesome guide + Icon page).

## Compatibility

No change for existing consumers: SVG stays the default `renderMode`, and `fluxRegisterIcons` keeps working (now `@deprecated` in favour of `configureIcons`).

## Verification

- `bun run --cwd packages/components build` (type-check + build) passes.
- Verified live in a downstream Nuxt app using a duotone webfont: admin, docs and the diagram viewer all render correctly.

https://claude.ai/code/session_01Rz3HjVLus5Cdjaxqu34ZRt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Icons can now render as SVGs or Font Awesome webfonts.
  * Added support for selecting icon styles, including solid, regular, light, thin, duotone, and brands.
  * Duotone font icons support layered primary and secondary styling.
  * Added configurable default styles and per-icon style overrides.

* **Documentation**
  * Updated icon and Font Awesome guides with configuration, rendering, styling, and usage details.
  * Documented limitations and requirements for font-mode icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->