### PR TITLE
fix(table): resolve a cell's column by accumulating colspans

### DIFF
--- a/docs/code/components/table/pinned-columns.vue
+++ b/docs/code/components/table/pinned-columns.vue
@@ -50,6 +50,25 @@
                     {{ project.budget }}
                 </FluxTableCell>
             </FluxTableRow>
+
+            <template #footer>
+                <FluxTableRow>
+                    <FluxTableCell
+                        :colspan="2"
+                        pinned>
+                        <strong>Total</strong>
+                    </FluxTableCell>
+
+                    <FluxTableCell :colspan="5"/>
+
+                    <FluxTableCell
+                        align="end"
+                        is-numeric
+                        pinned="end">
+                        € 215,350
+                    </FluxTableCell>
+                </FluxTableRow>
+            </template>
         </FluxTable>
     </FluxPane>
 </template>

--- a/docs/components/table/index.md
+++ b/docs/components/table/index.md
@@ -93,7 +93,7 @@ example=../../code/components/table/sticky.vue
 example=../../code/components/table/sticky-bar.vue
 :::
 
-::: example Pinned columns || A wide table with multiple columns pinned to the left and right edges.
+::: example Pinned columns || A wide table with multiple columns pinned to the left and right edges, and a footer built from spanning cells.
 example=../../code/components/table/pinned-columns.vue
 :::
 

--- a/packages/components/src/component/FluxTable.vue
+++ b/packages/components/src/component/FluxTable.vue
@@ -287,13 +287,21 @@
             let index = 0;
 
             for (const cell of unref(bodyRef)?.querySelector(`:scope > .${$style.tableRow}`)?.children ?? []) {
-                if (cell.classList.contains($style.isPinnedStart)) {
-                    startIndices.push(index);
-                } else if (cell.classList.contains($style.isPinnedEnd)) {
-                    endIndices.push(index);
+                const span = getColumnSpan(cell);
+                const isStart = cell.classList.contains($style.isPinnedStart);
+                const isEnd = cell.classList.contains($style.isPinnedEnd);
+
+                // Both lists hold columns, not cells: a spanning cell pins every
+                // column it covers, and each of those needs its own offset.
+                for (let covered = index; covered < index + span; covered++) {
+                    if (isStart) {
+                        startIndices.push(covered);
+                    } else if (isEnd) {
+                        endIndices.push(covered);
+                    }
                 }
 
-                index += getColumnSpan(cell);
+                index += span;
             }
         }
 

--- a/packages/components/src/component/FluxTable.vue
+++ b/packages/components/src/component/FluxTable.vue
@@ -93,7 +93,7 @@
     setup>
     import { animationFrameDebounce, useScrollPosition } from '@flux-ui/internals';
     import { computed, onMounted, onScopeDispose, provide, type Ref, ref, shallowReactive, shallowRef, unref, useId, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
-    import { useTableTree } from '~flux/components/composable/private';
+    import { countColumns, getColumnSpan, useTableTree } from '~flux/components/composable/private';
     import { type FluxTableColumnDef, FluxTableInjectionKey, type FluxTablePinnedEdges } from '~flux/components/data';
     import { subscribeToRootFontSize } from '~flux/components/util';
     import FluxPaneBody from './FluxPaneBody.vue';
@@ -250,7 +250,7 @@
         }
 
         const firstRow = unref(bodyRef)?.querySelector(`:scope > .${$style.tableRow}`);
-        fallbackColumnCount.value = firstRow?.children.length ?? 0;
+        fallbackColumnCount.value = countColumns(firstRow);
     }
 
     function areOffsetsEqual(a: Map<number, number>, b: Map<number, number>): boolean {
@@ -281,10 +281,20 @@
         let endIndices = columns.map((column, index) => column.pinned === 'end' ? index : -1).filter(index => index >= 0);
 
         if (columns.length === 0) {
-            const cells = Array.from(unref(bodyRef)?.querySelector(`:scope > .${$style.tableRow}`)?.children ?? []);
+            startIndices = [];
+            endIndices = [];
 
-            startIndices = cells.map((cell, index) => cell.classList.contains($style.isPinnedStart) ? index : -1).filter(index => index >= 0);
-            endIndices = cells.map((cell, index) => cell.classList.contains($style.isPinnedEnd) ? index : -1).filter(index => index >= 0);
+            let index = 0;
+
+            for (const cell of unref(bodyRef)?.querySelector(`:scope > .${$style.tableRow}`)?.children ?? []) {
+                if (cell.classList.contains($style.isPinnedStart)) {
+                    startIndices.push(index);
+                } else if (cell.classList.contains($style.isPinnedEnd)) {
+                    endIndices.push(index);
+                }
+
+                index += getColumnSpan(cell);
+            }
         }
 
         const edges: FluxTablePinnedEdges = {

--- a/packages/components/src/component/FluxTableCell.vue
+++ b/packages/components/src/component/FluxTableCell.vue
@@ -12,6 +12,8 @@
             isPinnedEdge && $style.isPinnedEdge
         )"
         role="cell"
+        :aria-colspan="colspan"
+        :aria-rowspan="rowspan"
         :style="cellStyle">
         <slot name="content">
             <slot/>
@@ -25,6 +27,7 @@
     import { clsx } from 'clsx';
     import { computed, unref, useTemplateRef, type VNode } from 'vue';
     import { useTableInjection } from '~flux/components/composable';
+    import { useTableColumnIndex } from '~flux/components/composable/private';
     import $style from '~flux/components/css/component/Table.module.scss';
 
     const {
@@ -62,13 +65,8 @@
 
     const isRaw = computed(() => 'content' in slots);
 
-    const columnIndex = computed(() => {
-        void columns.value;
-
-        const element = cell.value;
-
-        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
-    });
+    const columnIndex = useTableColumnIndex(cell, columns);
+    const columnSpan = computed(() => Math.max(colspan ?? 1, 1));
 
     // Spanning cells cover multiple columns, so their column's definition
     // (pinning, alignment, formatting) does not apply to them.
@@ -90,14 +88,16 @@
         return column.value?.pinned ?? null;
     });
 
+    // A spanning cell is the edge as soon as it covers the edge column, not only
+    // when it starts there.
     const isPinnedEdge = computed(() => {
         if (!pinnedSide.value) {
             return false;
         }
 
-        return pinnedSide.value === 'start'
-            ? columnIndex.value === pinnedEdges.value.start
-            : columnIndex.value === pinnedEdges.value.end;
+        const edge = pinnedSide.value === 'start' ? pinnedEdges.value.start : pinnedEdges.value.end;
+
+        return edge >= columnIndex.value && edge < columnIndex.value + columnSpan.value;
     });
 
     const cellStyle = computed(() => {
@@ -130,7 +130,10 @@
         }
 
         if (pinnedSide.value) {
-            const offset = pinnedOffsets.value.get(columnIndex.value) ?? 0;
+            // The offsets are measured per column, from the edge the column is
+            // pinned to; a spanning cell sits at the offset of the column it ends on.
+            const offsetIndex = pinnedSide.value === 'start' ? columnIndex.value : columnIndex.value + columnSpan.value - 1;
+            const offset = pinnedOffsets.value.get(offsetIndex) ?? 0;
 
             if (pinnedSide.value === 'start') {
                 style.left = `${offset}px`;

--- a/packages/components/src/component/FluxTableHeader.vue
+++ b/packages/components/src/component/FluxTableHeader.vue
@@ -64,7 +64,7 @@
     import { clsx } from 'clsx';
     import { computed, onUnmounted, unref, useTemplateRef, type VNode } from 'vue';
     import { useTableInjection } from '~flux/components/composable';
-    import { useTranslate } from '~flux/components/composable/private';
+    import { useTableColumnIndex, useTranslate } from '~flux/components/composable/private';
     import type { FluxTableColumnDef } from '~flux/components/data';
     import FluxFlyout from './FluxFlyout.vue';
     import FluxIcon from './FluxIcon.vue';
@@ -118,13 +118,7 @@
 
     const translate = useTranslate();
 
-    const columnIndex = computed(() => {
-        void columns.value;
-
-        const element = header.value;
-
-        return element?.parentElement ? Array.prototype.indexOf.call(element.parentElement.children, element) : -1;
-    });
+    const columnIndex = useTableColumnIndex(header, columns);
 
     const pinnedSide = computed<'start' | 'end' | null>(() => {
         if (pinned === true || pinned === 'start') {

--- a/packages/components/src/component/FluxTableRow.vue
+++ b/packages/components/src/component/FluxTableRow.vue
@@ -30,6 +30,7 @@
     import { clsx } from 'clsx';
     import { computed, onUnmounted, useTemplateRef, type VNode, watch } from 'vue';
     import { useTableInjection } from '~flux/components/composable';
+    import { resolveColumnIndex } from '~flux/components/composable/private';
     import $style from '~flux/components/css/component/Table.module.scss';
 
     const emit = defineEmits<{
@@ -99,9 +100,8 @@
         }
 
         const cell = target?.closest('[role="cell"], [role="columnheader"]');
-        const columnIndex = cell?.parentElement ? Array.prototype.indexOf.call(cell.parentElement.children, cell) : -1;
 
-        emit('rowClick', columnIndex, event);
+        emit('rowClick', resolveColumnIndex(cell), event);
     }
 
     function onKeydown(event: KeyboardEvent): void {

--- a/packages/components/src/composable/private/index.ts
+++ b/packages/components/src/composable/private/index.ts
@@ -7,6 +7,7 @@ export { default as useFormSelect } from './useFormSelect';
 export { useKanban } from './useKanban';
 export { default as useMenuFlyout, useMenuFlyoutContext, useMenuFlyoutProvider, type UseMenuFlyoutOptions, type UseMenuFlyoutProviderOptions, type UseMenuFlyoutReturn } from './useMenuFlyout';
 export { useSplitView, type SplitViewPane, type UseSplitViewOptions, type UseSplitViewReturn } from './useSplitView';
+export { countColumns, getColumnSpan, resolveColumnIndex, useTableColumnIndex } from './useTableColumnIndex';
 export { useTableTree, TREE_STEP, TREE_MARKER_SIZE } from './useTableTree';
 export { useTimeline } from './useTimeline';
 export { default as useTranslate } from './useTranslate';

--- a/packages/components/src/composable/private/useTableColumnIndex.ts
+++ b/packages/components/src/composable/private/useTableColumnIndex.ts
@@ -1,0 +1,64 @@
+import { computed, type ComputedRef, type Ref, unref } from 'vue';
+import type { FluxTableColumnDef } from '~flux/components/data';
+
+/**
+ * Returns how many columns a cell occupies. `aria-colspan` is the single place
+ * in the DOM that carries this, for assistive technology and for the column
+ * bookkeeping alike.
+ */
+export function getColumnSpan(element: Element): number {
+    const span = Number.parseInt(element.getAttribute('aria-colspan') ?? '', 10);
+
+    return Number.isNaN(span) || span < 1 ? 1 : span;
+}
+
+/**
+ * Counts the columns a row covers, spans included.
+ */
+export function countColumns(row: Element | null | undefined): number {
+    let count = 0;
+
+    for (const cell of row?.children ?? []) {
+        count += getColumnSpan(cell);
+    }
+
+    return count;
+}
+
+/**
+ * Resolves the column a cell starts in by accumulating the spans of the cells
+ * before it. Its sibling index would be one place to the left for every cell
+ * that follows a spanning one, taking pinning and column formatting with it.
+ */
+export function resolveColumnIndex(element: Element | null | undefined): number {
+    const parent = element?.parentElement;
+
+    if (!parent) {
+        return -1;
+    }
+
+    let index = 0;
+
+    for (const sibling of parent.children) {
+        if (sibling === element) {
+            return index;
+        }
+
+        index += getColumnSpan(sibling);
+    }
+
+    return -1;
+}
+
+/**
+ * Tracks the column a cell or header starts in. The columns are read purely to
+ * re-resolve the index once they change: that is the render pass in which the
+ * table settles into its final shape.
+ */
+export function useTableColumnIndex(element: Readonly<Ref<HTMLElement | null>>, columns: Readonly<Ref<readonly FluxTableColumnDef[]>>): ComputedRef<number> {
+    return computed(() => {
+        void columns.value;
+
+        return resolveColumnIndex(unref(element));
+    });
+}


### PR DESCRIPTION
Closes #35.

`FluxTableCell` worked out which column it was in from its position among its siblings, so a spanning cell shifted every cell after it in the row one place to the left. Pinning, alignment and formatting all key on that index, which is why a footer written as a `colspan` plus a total lost `pinned` and `isPinnedEdge` on its last cell.

## What changed

- Cells publish their span through `aria-colspan` (and `aria-rowspan`), which is where an ARIA table carries it anyway. That attribute is now the single source the column bookkeeping reads.
- New private composable `useTableColumnIndex`, plus the helpers `resolveColumnIndex`, `countColumns` and `getColumnSpan`. Resolving a column means walking the row and adding up the spans in front of the cell.
- `FluxTableCell` and `FluxTableHeader` take their index from it, `FluxTableRow` uses it for the `rowClick` column index, and `FluxTable` uses it for the two headerless fallbacks that count columns and locate the pinned edges from the first body row.
- A spanning cell now counts as the pinned edge as soon as it covers the edge column rather than only when it starts there, and an end-pinned spanning cell takes the offset of the column it ends on.

The alternative from the issue, an explicit `columnIndex` prop, was not taken: it leaves the trap in place and asks the caller to know about it.

## Docs

The pinned columns example grows a footer built from spanning cells, which is exactly the shape that used to break.

## Verification

`bun run --cwd packages/components build` and `bun run --cwd docs build` are green. The rendered docs page was compared before and after the change; on the footer row of the pinned columns example:

| | before | after |
|---|---|---|
| `Total` cell (`colspan=2`, `pinned`) | `is-pinned-start` | `is-pinned-start is-pinned-edge` |
| total cell (`pinned="end"`) | `is-pinned-end` | `is-pinned-end is-pinned-edge` |

The span accumulation itself was checked against the issue's seven-column footer, a row with two spanning cells, a plain row, degenerate spans (`0`, `-3`, missing) and detached elements.

## Out of scope

Cells in the rows below a `rowspan` can still resolve the wrong column; that needs an occupancy model across rows and stays documented as a limitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added footer support to the pinned-columns table example, including a total row with spanning cells.
* **Bug Fixes**
  * Improved pinned column positioning and edge detection for cells spanning multiple columns.
  * Improved column index calculations for table headers, cells, and row-click interactions.
* **Documentation**
  * Updated the Table documentation to describe the spanning-cell footer in the pinned-columns example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->