### PR TITLE
feat(table): write the clipboard from the table structure and add cell selection

### DIFF
--- a/docs/code/components/data-table/selection-copy.vue
+++ b/docs/code/components/data-table/selection-copy.vue
@@ -1,0 +1,97 @@
+<template>
+    <FluxPane>
+        <FluxDataTable
+            v-model:selected="selected"
+            :items="invoices"
+            :limits="[]"
+            :page="1"
+            :per-page="6"
+            selection-mode="multiple"
+            :total="invoices.length"
+            unique-key="id"
+            is-hoverable>
+            <template #selection="{count, clear, copy}">
+                <FluxFlexItem :grow="1">
+                    <FluxFlex
+                        align="center"
+                        :gap="9">
+                        <span aria-live="polite">{{ count }} selected</span>
+
+                        <FluxSpacer/>
+
+                        <FluxSecondaryButton
+                            icon-leading="copy"
+                            label="Copy"
+                            @click="onCopy(copy)"/>
+
+                        <FluxSecondaryButton
+                            label="Clear"
+                            @click="clear()"/>
+                    </FluxFlex>
+                </FluxFlexItem>
+            </template>
+
+            <template #header>
+                <FluxTableHeader>Invoice</FluxTableHeader>
+                <FluxTableHeader>Client</FluxTableHeader>
+                <FluxTableHeader
+                    align="end"
+                    is-numeric>Amount
+                </FluxTableHeader>
+                <FluxTableHeader is-shrinking>Due</FluxTableHeader>
+            </template>
+
+            <template #number="{item}">
+                <FluxTableCell>{{ item.number }}</FluxTableCell>
+            </template>
+
+            <template #client="{item}">
+                <FluxTableCell>{{ item.client }}</FluxTableCell>
+            </template>
+
+            <template #amount="{item}">
+                <FluxTableCell :copy-value="item.amount">{{ formatAmount(item.amount) }}</FluxTableCell>
+            </template>
+
+            <template #due="{item}">
+                <FluxTableCell :copy-value="item.due">{{ formatDue(item.due) }}</FluxTableCell>
+            </template>
+        </FluxDataTable>
+    </FluxPane>
+</template>
+
+<script
+    setup
+    lang="ts">
+    import { FluxDataTable, FluxFlex, FluxFlexItem, FluxPane, FluxSecondaryButton, FluxSpacer, FluxTableCell, FluxTableHeader, showSnackbar } from '@flux-ui/components';
+    import { DateTime } from 'luxon';
+    import { ref } from 'vue';
+
+    const selected = ref<number[]>([1, 3]);
+
+    const invoices = ref([
+        {id: 1, number: 'INV-1041', client: 'Northwind Trading', amount: 1284.5, due: '2026-08-14'},
+        {id: 2, number: 'INV-1042', client: 'Contoso Industries', amount: 640, due: '2026-08-21'},
+        {id: 3, number: 'INV-1043', client: 'Fabrikam Supplies', amount: 12750.75, due: '2026-09-01'},
+        {id: 4, number: 'INV-1044', client: 'Adventure Works', amount: 320.25, due: '2026-09-08'},
+        {id: 5, number: 'INV-1045', client: 'Litware Consulting', amount: 4980, due: '2026-09-15'},
+        {id: 6, number: 'INV-1046', client: 'Proseware Media', amount: 87.9, due: '2026-09-22'}
+    ]);
+
+    function formatAmount(amount: number): string {
+        return amount.toLocaleString('en-US', {style: 'currency', currency: 'USD'});
+    }
+
+    function formatDue(due: string): string {
+        return DateTime.fromISO(due).toLocaleString(DateTime.DATE_MED);
+    }
+
+    async function onCopy(copy: () => Promise<boolean>): Promise<void> {
+        if (await copy()) {
+            showSnackbar({
+                icon: 'circle-check',
+                message: 'Copied the selected rows to the clipboard.'
+            });
+        }
+    }
+</script>

--- a/docs/code/components/data-table/selection-copy.vue
+++ b/docs/code/components/data-table/selection-copy.vue
@@ -22,7 +22,7 @@
                         <FluxSecondaryButton
                             icon-leading="copy"
                             label="Copy"
-                            @click="onCopy(copy)"/>
+                            @click="copy()"/>
 
                         <FluxSecondaryButton
                             label="Clear"
@@ -63,7 +63,7 @@
 <script
     setup
     lang="ts">
-    import { FluxDataTable, FluxFlex, FluxFlexItem, FluxPane, FluxSecondaryButton, FluxSpacer, FluxTableCell, FluxTableHeader, showSnackbar } from '@flux-ui/components';
+    import { FluxDataTable, FluxFlex, FluxFlexItem, FluxPane, FluxSecondaryButton, FluxSpacer, FluxTableCell, FluxTableHeader } from '@flux-ui/components';
     import { DateTime } from 'luxon';
     import { ref } from 'vue';
 
@@ -84,14 +84,5 @@
 
     function formatDue(due: string): string {
         return DateTime.fromISO(due).toLocaleString(DateTime.DATE_MED);
-    }
-
-    async function onCopy(copy: () => Promise<boolean>): Promise<void> {
-        if (await copy()) {
-            showSnackbar({
-                icon: 'circle-check',
-                message: 'Copied the selected rows to the clipboard.'
-            });
-        }
     }
 </script>

--- a/docs/code/components/table/cell-selection.vue
+++ b/docs/code/components/table/cell-selection.vue
@@ -1,0 +1,64 @@
+<template>
+    <FluxPane>
+        <FluxPaneHeader
+            title="Revenue by region"
+            subtitle="Select a block of cells and copy it into a spreadsheet.">
+            <template #after>
+                <FluxSecondaryButton
+                    icon-leading="copy"
+                    label="Copy"
+                    @click="table?.copy()"/>
+            </template>
+        </FluxPaneHeader>
+
+        <FluxTable
+            ref="table"
+            is-cell-selectable>
+            <template #header>
+                <FluxTableRow>
+                    <FluxTableHeader>Region</FluxTableHeader>
+                    <FluxTableHeader
+                        v-for="quarter of quarters"
+                        :key="quarter"
+                        align="end"
+                        is-numeric>{{ quarter }}
+                    </FluxTableHeader>
+                </FluxTableRow>
+            </template>
+
+            <FluxTableRow
+                v-for="row of rows"
+                :key="row.region">
+                <FluxTableCell>{{ row.region }}</FluxTableCell>
+
+                <FluxTableCell
+                    v-for="(value, index) of row.values"
+                    :key="index"
+                    :copy-value="value">{{ formatAmount(value) }}
+                </FluxTableCell>
+            </FluxTableRow>
+        </FluxTable>
+    </FluxPane>
+</template>
+
+<script
+    setup
+    lang="ts">
+    import { FluxPane, FluxPaneHeader, FluxSecondaryButton, FluxTable, FluxTableCell, FluxTableHeader, FluxTableRow } from '@flux-ui/components';
+    import { useTemplateRef } from 'vue';
+
+    const table = useTemplateRef('table');
+
+    const quarters = ['Q1', 'Q2', 'Q3', 'Q4'];
+
+    const rows = [
+        {region: 'Benelux', values: [128400, 141200, 137850, 152300]},
+        {region: 'Nordics', values: [98250, 102400, 111900, 118650]},
+        {region: 'DACH', values: [211300, 224750, 219400, 238100]},
+        {region: 'Iberia', values: [74600, 81250, 79900, 88400]}
+    ];
+
+    function formatAmount(value: number): string {
+        return value.toLocaleString('en-US', {style: 'currency', currency: 'EUR', maximumFractionDigits: 0});
+    }
+</script>

--- a/docs/components/data-table.md
+++ b/docs/components/data-table.md
@@ -31,6 +31,12 @@ props:
         description: The data to show in the table. This should already be the current page's data. Pagination is handled server-side. Pass the subset of items for the active page here.
         type: T[]
 
+    -   name: is-cell-selectable
+        description: Enables spreadsheet-style cell selection, so a rectangle of cells can be dragged or walked with the arrow keys and copied as a grid. Requires rows that are not interactive, so it cannot be combined with `selection-mode` or a `row-click` listener; doing so logs a warning and leaves the mode off. See the table's own documentation for the keyboard model.
+        type: boolean
+        optional: true
+        default: false
+
     -   name: is-filled
         description: Renders a filler row that stretches to the bottom of the table when the page has fewer items than `per-page`.
         type: boolean

--- a/docs/components/data-table.md
+++ b/docs/components/data-table.md
@@ -218,7 +218,7 @@ render=../code/components/data-table/preview.vue
 <FrontmatterDocs/>
 
 ::: info Copying the selection
-The `selection` slot binds a `copy()` that writes the selected rows to the clipboard, column headers included, as tab separated text and as table markup a spreadsheet understands. It reads the rendered rows, because only the DOM knows what a column made of an item, so a selection that reaches beyond the current page is copied as far as it is rendered. Give a formatted cell a `copy-value` to have it paste as the value behind it. See [Copying data](./table#copying-data) for what the table leaves out.
+The `selection` slot binds a `copy()` that writes the selected rows to the clipboard, column headers included, as tab-separated text and as table markup a spreadsheet understands. It reads the rendered rows, because only the DOM knows what a column made of an item, so a selection that reaches beyond the current page is copied as far as it is rendered. Give a formatted cell a `copy-value` to have it paste as the value behind it. See [Copying data](./table#copying-data) for what the table leaves out.
 :::
 
 ::: info Server-side pagination

--- a/docs/components/data-table.md
+++ b/docs/components/data-table.md
@@ -125,6 +125,7 @@ slots:
             selected: (string | number)[]
             count: number
             clear: () => void
+            copy: () => Promise<boolean>
 
     -   name: filter
         description: Renders above the table header, typically a `FluxFilterBar` for filtering the data set.
@@ -210,6 +211,10 @@ render=../code/components/data-table/preview.vue
 
 <FrontmatterDocs/>
 
+::: info Copying the selection
+The `selection` slot binds a `copy()` that writes the selected rows to the clipboard, column headers included, as tab separated text and as table markup a spreadsheet understands. It reads the rendered rows, because only the DOM knows what a column made of an item, so a selection that reaches beyond the current page is copied as far as it is rendered. Give a formatted cell a `copy-value` to have it paste as the value behind it. See [Copying data](./table#copying-data) for what the table leaves out.
+:::
+
 ::: info Server-side pagination
 The data table does **not** paginate `items` internally. The `items` prop should contain only the rows for the currently active page, fetched from your server or API. The `page` and `per-page` props are used to drive the pagination bar and are exposed through slot bindings so you can display them, but the component never slices or filters the `items` array itself.
 :::
@@ -250,6 +255,10 @@ example=../code/components/data-table/selection-single.vue
 
 ::: example Selection toolbar || A bar with bulk actions that takes the place of the filter bar while rows are selected.
 example=../code/components/data-table/selection-toolbar.vue
+:::
+
+::: example Copy the selection || A selection bar that copies the selected rows to the clipboard, with the amounts and dates pasting as their raw values.
+example=../code/components/data-table/selection-copy.vue
 :::
 
 ::: example Sortable columns || A data table whose columns drive a single, coordinated client-side sort.

--- a/docs/components/table/cell.md
+++ b/docs/components/table/cell.md
@@ -23,6 +23,11 @@ props:
         type: number
         optional: true
 
+    -   name: copy-value
+        description: The value the cell hands to the clipboard instead of the text it renders. Use it so a formatted date or amount pastes into a spreadsheet as the value behind it, for example `1234.56` for `$ 1,234.56`.
+        type: [ 'string', 'number' ]
+        optional: true
+
     -   name: is-numeric
         description: Renders the cell content with tabular (monospaced) figures. Use for numeric columns so digits align vertically. Combine with `align` set to `end` for right-aligned numbers. Also inherited from the column's header, which is preferred for whole columns.
         type: boolean

--- a/docs/components/table/index.md
+++ b/docs/components/table/index.md
@@ -80,7 +80,7 @@ While `is-loading` is set the table exposes `aria-busy` on the table element, so
 
 The table is a CSS grid rather than a `<table>`, and a browser copying a grid of
 elements hands over one line per cell with nothing marking where a row ends. The
-table therefore writes the clipboard itself, tab separated for a spreadsheet and
+table therefore writes the clipboard itself, tab-separated for a spreadsheet and
 as real table markup for anything that reads HTML. What it copies follows how far
 the selection reaches:
 

--- a/docs/components/table/index.md
+++ b/docs/components/table/index.md
@@ -67,7 +67,40 @@ render=../../code/components/table/preview.vue
 :::
 
 ::: info Accessible loading
-While `is-loading` is set the table exposes `aria-busy` on the underlying `<table>`, so assistive technologies announce that the data is updating.
+While `is-loading` is set the table exposes `aria-busy` on the table element, so assistive technologies announce that the data is updating.
+:::
+
+## Copying data
+
+The table is a CSS grid rather than a `<table>`, and a browser copying a grid of
+elements hands over one line per cell with nothing marking where a row ends. The
+table therefore writes the clipboard itself, tab separated for a spreadsheet and
+as real table markup for anything that reads HTML. What it copies follows how far
+the selection reaches:
+
+- **Across several rows** it copies those rows whole, with the column headers in
+  front of them. A drag ends halfway through its first and last row, which would
+  otherwise copy those two short of the rows in between.
+- **Within one row** it copies the cells that were dragged over, without headers.
+- **Within one cell** it stays out of the way, so dragging over a few words still
+  copies those words.
+
+Two attributes steer what ends up on the clipboard, and both work on any element
+inside the table:
+
+- `data-flux-copy-value` states the value a cell copies instead of the text it
+  renders. [Cell](./cell) takes it as the `copy-value` prop.
+- `data-flux-copy="none"` leaves something out. On a row or a cell it drops that
+  row or cell entirely; inside a cell it only drops that subtree's text, so the
+  cell still copies as an empty column and the columns stay aligned.
+
+The table bar, the filler row and the sort and resize controls carry it already,
+as do the selection and expand columns of the [Data table](../data-table).
+
+::: tip Copying without a selection
+The table instance exposes `copy(rows?)`, which writes the whole table to the
+clipboard, or only the rows that are passed to it. The data table builds its
+selection bar's `copy()` on top of it.
 :::
 
 <FrontmatterDocs/>

--- a/docs/components/table/index.md
+++ b/docs/components/table/index.md
@@ -13,6 +13,12 @@ props:
         optional: true
         default: bottom
 
+    -   name: is-cell-selectable
+        description: Enables spreadsheet-style cell selection over the table body, so a rectangle of cells can be dragged with the pointer or walked with the arrow keys and copied as a grid. The table becomes a `grid` for assistive technology and its own tab stop. Cannot be combined with clickable rows, which claim the same keys.
+        type: boolean
+        optional: true
+        default: false
+
     -   name: is-filled
         description: Renders a filler row that stretches to the bottom of the table, so the column dividers reach the bottom on full-height tables.
         type: boolean
@@ -98,9 +104,50 @@ The table bar, the filler row and the sort and resize controls carry it already,
 as do the selection and expand columns of the [Data table](../data-table).
 
 ::: tip Copying without a selection
-The table instance exposes `copy(rows?)`, which writes the whole table to the
-clipboard, or only the rows that are passed to it. The data table builds its
+The table instance exposes `copy(rows?)`, which writes the rows passed to it to
+the clipboard. Called without arguments it copies the current cell selection when
+there is one, and the whole table when there is not. The data table builds its
 selection bar's `copy()` on top of it.
+:::
+
+## Cell selection
+
+`is-cell-selectable` turns the body into a grid of selectable cells, the way a
+spreadsheet behaves: drag a rectangle with the pointer, shift-click to extend it,
+or walk it with the keyboard. The block is outlined as a whole, with the active
+cell held a shade darker inside it.
+
+Copying a rectangle hands over exactly that rectangle, so it pastes into a
+spreadsheet in the shape it was selected. `Ctrl`/`Cmd` + `C` does it, and so does
+the table instance's `copy()` when called without arguments, which is what a copy
+button of your own would reach for.
+
+The table itself becomes the tab stop and names the active cell through
+`aria-activedescendant`, which keeps a table of a thousand cells to one focusable
+element. It reports itself as a `grid` while the mode is on, and its cells as
+`gridcell`.
+
+| Key | Does |
+| --- | --- |
+| `Arrow` keys | Move the active cell |
+| `Shift` + arrow | Extend the rectangle |
+| `Home` / `End` | First or last cell of the row |
+| `Ctrl`/`Cmd` + `Home` / `End` | First or last cell of the table |
+| `Ctrl`/`Cmd` + `A` | Select every cell |
+| `Ctrl`/`Cmd` + `C` | Copy the rectangle |
+| `Escape` | Clear the selection |
+
+The selection is also cleared by clicking outside the table, and by the instance's
+`clearSelection()`. A copy button of your own placed outside the table still works:
+the click is handled before the selection is dropped.
+
+::: warning Not alongside clickable rows
+Clickable rows own the roving tabindex, `Enter`, `Space` and the arrow keys, so
+they cannot share a table with cell selection. On `FluxDataTable` that means no
+`selection-mode` and no `row-click` listener; passing `is-cell-selectable`
+anyway logs a warning and leaves the mode off. Selecting text inside the table is
+off while the mode is on, since a text range and a cell rectangle would fight
+over the same drag.
 :::
 
 <FrontmatterDocs/>
@@ -149,6 +196,10 @@ example=../../code/components/table/spanning.vue
 
 ::: example Spanning rows || A first column whose cell spans every row of its track through `rowspan`.
 example=../../code/components/table/rowspan.vue
+:::
+
+::: example Cell selection || A table whose cells are selected as a rectangle and copied as a grid, with the amounts pasting as their raw values.
+example=../../code/components/table/cell-selection.vue
 :::
 
 ::: example Footer totals || Line items with a footer that sums the amounts across spanning cells.

--- a/docs/components/table/index.md
+++ b/docs/components/table/index.md
@@ -117,10 +117,16 @@ spreadsheet behaves: drag a rectangle with the pointer, shift-click to extend it
 or walk it with the keyboard. The block is outlined as a whole, with the active
 cell held a shade darker inside it.
 
+The column headers are part of the grid, so clicking one selects that whole
+column, header included, and shift-clicking a second extends it to a range of
+columns. The sort button and the resize grip keep their own behavior.
+
 Copying a rectangle hands over exactly that rectangle, so it pastes into a
 spreadsheet in the shape it was selected. `Ctrl`/`Cmd` + `C` does it, and so does
 the table instance's `copy()` when called without arguments, which is what a copy
-button of your own would reach for.
+button of your own would reach for. A rectangle taken from the body brings the
+headers of the columns it covers along, unless it already holds them or stays
+within a single row.
 
 The table itself becomes the tab stop and names the active cell through
 `aria-activedescendant`, which keeps a table of a thousand cells to one focusable
@@ -136,6 +142,9 @@ element. It reports itself as a `grid` while the mode is on, and its cells as
 | `Ctrl`/`Cmd` + `A` | Select every cell |
 | `Ctrl`/`Cmd` + `C` | Copy the rectangle |
 | `Escape` | Clear the selection |
+
+`Ctrl`/`Cmd` + `A` and `Ctrl`/`Cmd` + `Home` reach the header row too, since it is
+row one of the grid. Tabbing in lands on the first data cell rather than a header.
 
 The selection is also cleared by clicking outside the table, and by the instance's
 `clearSelection()`. A copy button of your own placed outside the table still works:

--- a/docs/guide/composables/useTableInjection.md
+++ b/docs/guide/composables/useTableInjection.md
@@ -7,13 +7,14 @@ This composable provides access to the [Table](../../components/table/) layout c
 ```ts
 import { useTableInjection } from '@flux-ui/components';
 
-const { pinnedEdges, pinnedOffsets, registerColumn } = useTableInjection();
+const { cellRole, pinnedEdges, pinnedOffsets, registerColumn } = useTableInjection();
 ```
 
 ## Type declarations
 
 ```ts
 declare function useTableInjection(): {
+    readonly cellRole: Readonly<Ref<'cell' | 'gridcell'>>;
     readonly pinnedEdges: Ref<{ readonly end: number; readonly start: number; }>;
     readonly pinnedOffsets: Ref<Map<number, number>>;
 
@@ -21,6 +22,7 @@ declare function useTableInjection(): {
 };
 ```
 
+- `cellRole`: the role a cell has to render, which becomes `gridcell` while the table is `is-cell-selectable`. Bind it on a hand-built cell so it joins the cell selection.
 - `pinnedEdges`: the column index of the last start-pinned column and the first end-pinned column (`-1` when there is none). Used to render the scroll shadow on the outermost pinned column.
 - `pinnedOffsets`: the sticky offset in pixels for each pinned column, keyed by column index.
 - `registerColumn`: registers a column definition (sizing and pinning) for the table's `grid-template-columns`. Returns an unregister function.

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -489,7 +489,7 @@
     });
 
     watchEffect(() => {
-        if (isCellSelectable && unref(isRowInteractive)) {
+        if (import.meta.env.DEV && isCellSelectable && unref(isRowInteractive)) {
             warn('FluxDataTable: is-cell-selectable is ignored while the rows are interactive. Remove selection-mode and the row-click listener, or drop is-cell-selectable.');
         }
     });

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -2,6 +2,7 @@
     <FluxTable
         ref="table"
         :aria-rowcount="total + 1"
+        :is-cell-selectable="isCellSelectable && !isRowInteractive"
         :is-filled="limitedItems.length !== 0 && isFilled"
         :is-hoverable="isHoverable"
         :is-loading="isLoading"
@@ -176,9 +177,10 @@
     lang="ts"
     setup
     generic="T extends Record<string, any>">
+    import { warn } from '@flux-ui/internals';
     import type { FluxColor } from '@flux-ui/types';
     import { clsx } from 'clsx';
-    import { computed, getCurrentInstance, unref, useTemplateRef, type VNode, watch } from 'vue';
+    import { computed, getCurrentInstance, unref, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
     import FluxTableActions from './table/FluxTableActions.vue';
     import { useDisabledInjection } from '~flux/components/composable';
     import { useTranslate } from '~flux/components/composable/private';
@@ -231,6 +233,7 @@
         collapseMode = 'unmount',
         expandMode = 'multiple',
         groupBy,
+        isCellSelectable = false,
         isFilled = false,
         isHoverable = false,
         isLoading = false,
@@ -247,6 +250,7 @@
         readonly collapseMode?: 'hide' | 'unmount';
         readonly expandMode?: 'single' | 'multiple';
         readonly groupBy?: (item: T) => SelectionId;
+        readonly isCellSelectable?: boolean;
         readonly isFilled?: boolean;
         readonly isHoverable?: boolean;
         readonly isLoading?: boolean;
@@ -480,6 +484,14 @@
 
     watch(() => items, () => {
         unref(table)?.$el.scrollTo(0, 0);
+    });
+
+    // Both claim the roving tabindex, Enter and the arrow keys, so cell selection
+    // stands down rather than half-working next to an interactive row.
+    watchEffect(() => {
+        if (isCellSelectable && unref(isRowInteractive)) {
+            warn('FluxDataTable: is-cell-selectable is ignored while the rows are interactive. Remove selection-mode and the row-click listener, or drop is-cell-selectable.');
+        }
     });
 
     function clearSelection(): void {

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -12,7 +12,7 @@
             <FluxTableBar v-if="hasSelectionBar">
                 <slot
                     name="selection"
-                    v-bind="{selected: selectedIds, count: selectedCount, clear: clearSelection}"/>
+                    v-bind="{selected: selectedIds, count: selectedCount, clear: clearSelection, copy: copySelection}"/>
             </FluxTableBar>
 
             <slot
@@ -25,7 +25,8 @@
                     v-if="selectionMode"
                     is-shrinking
                     :pinned="leadingPinned ? 'start' : undefined"
-                    :class="$style.tableCellSelection">
+                    :class="$style.tableCellSelection"
+                    data-flux-copy="none">
                     <FluxFormCheckbox
                         v-if="selectionMode === 'multiple'"
                         :model-value="selectAllState"
@@ -36,7 +37,8 @@
                     v-if="hasExpandable"
                     is-shrinking
                     :pinned="leadingPinned ? 'start' : undefined"
-                    :class="$style.tableCellExpand"/>
+                    :class="$style.tableCellExpand"
+                    data-flux-copy="none"/>
 
                 <slot
                     name="header"
@@ -99,7 +101,8 @@
                     @row-click="(columnIndex, event) => onRowClick(entry.item, columnIndex, event)">
                     <FluxTableCell
                         v-if="selectionMode"
-                        :class="$style.tableCellSelection">
+                        :class="$style.tableCellSelection"
+                        data-flux-copy="none">
                         <FluxFormCheckbox
                             :model-value="rowStates.get(entry.key)?.isSelected"
                             @update:model-value="onSelectRow(entry.item)"/>
@@ -107,7 +110,8 @@
 
                     <FluxTableCell
                         v-if="hasExpandable"
-                        :class="$style.tableCellExpand">
+                        :class="$style.tableCellExpand"
+                        data-flux-copy="none">
                         <FluxTableActions v-if="rowStates.get(entry.key)?.isExpandable">
                             <FluxAction
                                 :class="clsx($style.tableExpandToggle, rowStates.get(entry.key)?.isExpanded && $style.isExpanded)"
@@ -299,6 +303,8 @@
             readonly count: number;
 
             clear(): void;
+
+            copy(): Promise<boolean>;
         }): VNode;
 
         expandable(props: {
@@ -428,7 +434,7 @@
     const collapsedGroupSet = computed<ReadonlySet<SelectionId>>(() => new Set(unref(collapsedGroups)));
 
     const rowStates = computed(() => {
-        const states = new Map<SelectionId, { color: FluxColor | undefined; isExpandable: boolean; isExpanded: boolean; isSelected: boolean }>();
+        const states = new Map<SelectionId, { color: FluxColor | undefined; isExpandable: boolean; isExpanded: boolean; isSelected: boolean | undefined }>();
 
         for (const chunk of unref(renderChunks)) {
             for (const entry of chunk.entries) {
@@ -436,7 +442,9 @@
                     color: rowColor?.(entry.item),
                     isExpandable: isRowExpandable(entry.item),
                     isExpanded: isItemExpanded(entry.item),
-                    isSelected: isItemSelected(entry.item)
+                    // Left undefined without a selection mode: the row would otherwise
+                    // report aria-selected="false" and promise a selection that is not there.
+                    isSelected: selectionMode ? isItemSelected(entry.item) : undefined
                 });
             }
         }
@@ -476,6 +484,20 @@
 
     function clearSelection(): void {
         selected.value = selectionMode === 'multiple' ? [] : null;
+    }
+
+    // Reads the rendered rows rather than the items: only the DOM knows what a
+    // column made of an item. A selection reaching beyond the current page is
+    // therefore copied as far as it is rendered.
+    function copySelection(): Promise<boolean> {
+        const tableRef = unref(table);
+        const rows = (tableRef?.$el as HTMLElement | undefined)?.querySelectorAll<HTMLElement>('[role="row"][aria-selected="true"]');
+
+        if (!tableRef || !rows?.length) {
+            return Promise.resolve(false);
+        }
+
+        return tableRef.copy(Array.from(rows));
     }
 
     function getItemId(item: T): SelectionId | undefined {

--- a/packages/components/src/component/FluxDataTable.vue
+++ b/packages/components/src/component/FluxDataTable.vue
@@ -2,7 +2,7 @@
     <FluxTable
         ref="table"
         :aria-rowcount="total + 1"
-        :is-cell-selectable="isCellSelectable && !isRowInteractive"
+        :is-cell-selectable="hasCellSelection"
         :is-filled="limitedItems.length !== 0 && isFilled"
         :is-hoverable="isHoverable"
         :is-loading="isLoading"
@@ -163,7 +163,7 @@
             #empty>
             <div
                 :class="$style.tableCellBase"
-                role="cell"
+                :role="cellRole"
                 :style="{gridColumn: '1 / -1'}">
                 <slot name="empty">
                     <div :class="$style.tableEmpty">{{ translate('flux.noItems') }}</div>
@@ -346,6 +346,8 @@
 
     const hasRowClickListener = computed(() => !!instance?.vnode?.props?.onRowClick);
     const isRowInteractive = computed(() => (!!selectionMode && !unref(treeDisabled)) || unref(hasRowClickListener));
+    const hasCellSelection = computed(() => isCellSelectable && !unref(isRowInteractive));
+    const cellRole = computed(() => unref(hasCellSelection) ? 'gridcell' : 'cell');
 
     const limitedItems = computed(() => items.slice(0, perPage));
 
@@ -486,8 +488,6 @@
         unref(table)?.$el.scrollTo(0, 0);
     });
 
-    // Both claim the roving tabindex, Enter and the arrow keys, so cell selection
-    // stands down rather than half-working next to an interactive row.
     watchEffect(() => {
         if (isCellSelectable && unref(isRowInteractive)) {
             warn('FluxDataTable: is-cell-selectable is ignored while the rows are interactive. Remove selection-mode and the row-click listener, or drop is-cell-selectable.');
@@ -499,17 +499,13 @@
     }
 
     // Reads the rendered rows rather than the items: only the DOM knows what a
-    // column made of an item. A selection reaching beyond the current page is
-    // therefore copied as far as it is rendered.
+    // column made of an item, so a selection beyond the current page is copied as
+    // far as it is rendered.
     function copySelection(): Promise<boolean> {
         const tableRef = unref(table);
         const rows = (tableRef?.$el as HTMLElement | undefined)?.querySelectorAll<HTMLElement>('[role="row"][aria-selected="true"]');
 
-        if (!tableRef || !rows?.length) {
-            return Promise.resolve(false);
-        }
-
-        return tableRef.copy(Array.from(rows));
+        return rows?.length ? tableRef!.copy(Array.from(rows)) : Promise.resolve(false);
     }
 
     function getItemId(item: T): SelectionId | undefined {

--- a/packages/components/src/component/table/FluxTable.vue
+++ b/packages/components/src/component/table/FluxTable.vue
@@ -3,6 +3,7 @@
         ref="base"
         :class="[
             $style.table,
+            isCellSelectable && $style.isCellSelectable,
             isHoverable && $style.isHoverable,
             isSticky && $style.isSticky
         ]"
@@ -10,10 +11,13 @@
         <div
             ref="grid"
             :class="$style.tableBase"
-            role="table"
+            :role="isCellSelectable ? 'grid' : 'table'"
+            :aria-activedescendant="activeCellId"
             :aria-busy="isLoading || undefined"
             :aria-describedby="slots.caption ? captionId : undefined"
+            :aria-multiselectable="isCellSelectable || undefined"
             :aria-rowcount="ariaRowcount"
+            :tabindex="isCellSelectable ? 0 : undefined"
             :style="{gridTemplateRows: resolveGridTemplateRows()}">
             <div
                 v-if="slots.header"
@@ -95,8 +99,8 @@
     setup>
     import { useScrollPosition } from '@basmilius/common';
     import { animationFrameDebounce } from '@basmilius/utils';
-    import { computed, onMounted, onScopeDispose, provide, type Ref, ref, shallowReactive, shallowRef, unref, useId, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
-    import { countColumns, getColumnSpan, useTableClipboard, useTableTree } from '~flux/components/composable/private';
+    import { computed, onMounted, onScopeDispose, provide, type Ref, ref, shallowReactive, shallowRef, toRef, unref, useId, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
+    import { countColumns, getColumnSpan, useTableCellSelection, useTableClipboard, useTableTree } from '~flux/components/composable/private';
     import { type FluxTableColumnDef, FluxTableInjectionKey, type FluxTablePinnedEdges } from '~flux/components/data';
     import { subscribeToRootFontSize } from '~flux/components/util';
     import FluxPaneBody from '../FluxPaneBody.vue';
@@ -112,6 +116,7 @@
 
     const {
         captionSide = 'bottom',
+        isCellSelectable = false,
         isFilled = false,
         isHoverable = false,
         isLoading = false,
@@ -119,6 +124,7 @@
     } = defineProps<{
         readonly ariaRowcount?: number;
         readonly captionSide?: 'top' | 'bottom';
+        readonly isCellSelectable?: boolean;
         readonly isFilled?: boolean;
         readonly isHoverable?: boolean;
         readonly isLoading?: boolean;
@@ -154,7 +160,10 @@
     const pinnedOffsets = shallowRef(new Map<number, number>());
     const columnRegistrations = shallowReactive(new Set<ColumnRegistration>());
 
-    const {copy} = useTableClipboard(base);
+    const cellRole = computed<'cell' | 'gridcell'>(() => isCellSelectable ? 'gridcell' : 'cell');
+
+    const {activeCellId, clear: clearSelection, getSelectedCells} = useTableCellSelection(gridRef, bodyRef, toRef(() => isCellSelectable));
+    const {copy} = useTableClipboard(base, {getSelectedCells});
     const {registerTreeNode, treeLines} = useTableTree(bodyRef);
 
     const isScrolledStart = computed(() => x.value > 0);
@@ -480,6 +489,7 @@
 
     provide(FluxTableInjectionKey, {
         activeRow,
+        cellRole,
         columns: sortedColumns,
         pinnedEdges,
         pinnedOffsets,
@@ -488,6 +498,7 @@
     });
 
     defineExpose({
+        clearSelection,
         columns: sortedColumns,
         copy
     });

--- a/packages/components/src/component/table/FluxTable.vue
+++ b/packages/components/src/component/table/FluxTable.vue
@@ -162,8 +162,8 @@
 
     const cellRole = computed<'cell' | 'gridcell'>(() => isCellSelectable ? 'gridcell' : 'cell');
 
-    const {activeCellId, clear: clearSelection, getSelectedCells} = useTableCellSelection(gridRef, bodyRef, toRef(() => isCellSelectable));
-    const {copy} = useTableClipboard(base, {getSelectedCells});
+    const {activeCellId, clear: clearSelection, getSelectedCells, getSelectedHeaders} = useTableCellSelection(gridRef, toRef(() => isCellSelectable));
+    const {copy} = useTableClipboard(base, {getSelectedCells, getSelectedHeaders});
     const {registerTreeNode, treeLines} = useTableTree(bodyRef);
 
     const isScrolledStart = computed(() => x.value > 0);

--- a/packages/components/src/component/table/FluxTable.vue
+++ b/packages/components/src/component/table/FluxTable.vue
@@ -45,7 +45,8 @@
             <FluxTableRow
                 v-if="isFilled"
                 :class="$style.tableFill"
-                aria-hidden="true">
+                aria-hidden="true"
+                data-flux-copy="none">
                 <FluxTableCell
                     v-for="n of fillCellCount"
                     :key="n"/>
@@ -53,7 +54,8 @@
 
             <FluxTableRow
                 v-if="slots.empty"
-                :class="$style.tableEmptyFill">
+                :class="$style.tableEmptyFill"
+                data-flux-copy="none">
                 <slot name="empty"/>
             </FluxTableRow>
 
@@ -94,7 +96,7 @@
     import { useScrollPosition } from '@basmilius/common';
     import { animationFrameDebounce } from '@basmilius/utils';
     import { computed, onMounted, onScopeDispose, provide, type Ref, ref, shallowReactive, shallowRef, unref, useId, useTemplateRef, type VNode, watch, watchEffect } from 'vue';
-    import { countColumns, getColumnSpan, useTableTree } from '~flux/components/composable/private';
+    import { countColumns, getColumnSpan, useTableClipboard, useTableTree } from '~flux/components/composable/private';
     import { type FluxTableColumnDef, FluxTableInjectionKey, type FluxTablePinnedEdges } from '~flux/components/data';
     import { subscribeToRootFontSize } from '~flux/components/util';
     import FluxPaneBody from '../FluxPaneBody.vue';
@@ -152,6 +154,7 @@
     const pinnedOffsets = shallowRef(new Map<number, number>());
     const columnRegistrations = shallowReactive(new Set<ColumnRegistration>());
 
+    const {copy} = useTableClipboard(base);
     const {registerTreeNode, treeLines} = useTableTree(bodyRef);
 
     const isScrolledStart = computed(() => x.value > 0);
@@ -485,6 +488,7 @@
     });
 
     defineExpose({
-        columns: sortedColumns
+        columns: sortedColumns,
+        copy
     });
 </script>

--- a/packages/components/src/component/table/FluxTableActions.vue
+++ b/packages/components/src/component/table/FluxTableActions.vue
@@ -1,5 +1,7 @@
 <template>
-    <FluxActionStack :class="$style.tableActions">
+    <FluxActionStack
+        :class="$style.tableActions"
+        data-flux-copy="none">
         <slot/>
     </FluxActionStack>
 </template>

--- a/packages/components/src/component/table/FluxTableBar.vue
+++ b/packages/components/src/component/table/FluxTableBar.vue
@@ -5,7 +5,7 @@
         data-flux-copy="none">
         <div
             :class="$style.tableBar"
-            role="cell">
+            :role="cellRole">
             <div :class="$style.tableBarContent">
                 <slot/>
             </div>
@@ -17,9 +17,12 @@
     lang="ts"
     setup>
     import type { VNode } from 'vue';
+    import { useTableInjection } from '~flux/components/composable';
     import $style from '~flux/components/css/component/Table.module.scss';
 
     defineSlots<{
         default(): VNode[];
     }>();
+
+    const {cellRole} = useTableInjection();
 </script>

--- a/packages/components/src/component/table/FluxTableBar.vue
+++ b/packages/components/src/component/table/FluxTableBar.vue
@@ -1,7 +1,8 @@
 <template>
     <div
         :class="$style.tableRow"
-        role="row">
+        role="row"
+        data-flux-copy="none">
         <div
             :class="$style.tableBar"
             role="cell">

--- a/packages/components/src/component/table/FluxTableCell.vue
+++ b/packages/components/src/component/table/FluxTableCell.vue
@@ -14,6 +14,7 @@
         role="cell"
         :aria-colspan="colspan"
         :aria-rowspan="rowspan"
+        :data-flux-copy-value="copyValue"
         :style="cellStyle">
         <slot name="content">
             <slot/>
@@ -44,6 +45,7 @@
         readonly colspan?: number;
         readonly contentDirection?: 'column' | 'row';
         readonly contentGap?: number;
+        readonly copyValue?: string | number;
         readonly isNumeric?: boolean;
         readonly noWrap?: boolean;
         readonly pinned?: boolean | 'start' | 'end';

--- a/packages/components/src/component/table/FluxTableCell.vue
+++ b/packages/components/src/component/table/FluxTableCell.vue
@@ -11,7 +11,7 @@
             pinnedSide === 'end' && $style.isPinnedEnd,
             isPinnedEdge && $style.isPinnedEdge
         )"
-        role="cell"
+        :role="cellRole"
         :aria-colspan="colspan"
         :aria-rowspan="rowspan"
         :data-flux-copy-value="copyValue"
@@ -60,6 +60,7 @@
     const cell = useTemplateRef('cell');
 
     const {
+        cellRole,
         columns,
         pinnedEdges,
         pinnedOffsets

--- a/packages/components/src/component/table/FluxTableGroup.vue
+++ b/packages/components/src/component/table/FluxTableGroup.vue
@@ -11,7 +11,8 @@
                     $style.tableGroup,
                     isExpandable && $style.isHoverable
                 )"
-                :role="cellRole">
+                :role="cellRole"
+                :aria-colspan="columns.length || undefined">
                 <component
                     :is="isExpandable ? 'button' : 'div'"
                     :class="$style.tableGroupContent"
@@ -79,7 +80,7 @@
         after?(): VNode[];
     }>();
 
-    const {cellRole} = useTableInjection();
+    const {cellRole, columns} = useTableInjection();
     const translate = useTranslate();
 
     const hasRows = computed(() => 'default' in slots);

--- a/packages/components/src/component/table/FluxTableGroup.vue
+++ b/packages/components/src/component/table/FluxTableGroup.vue
@@ -11,7 +11,7 @@
                     $style.tableGroup,
                     isExpandable && $style.isHoverable
                 )"
-                role="cell">
+                :role="cellRole">
                 <component
                     :is="isExpandable ? 'button' : 'div'"
                     :class="$style.tableGroupContent"
@@ -54,6 +54,7 @@
     import type { FluxIconName } from '@flux-ui/types';
     import { clsx } from 'clsx';
     import { computed, type VNode } from 'vue';
+    import { useTableInjection } from '~flux/components/composable';
     import { useTranslate } from '~flux/components/composable/private';
     import FluxIcon from '../FluxIcon.vue';
     import { PassThrough } from '../primitive';
@@ -78,6 +79,7 @@
         after?(): VNode[];
     }>();
 
+    const {cellRole} = useTableInjection();
     const translate = useTranslate();
 
     const hasRows = computed(() => 'default' in slots);

--- a/packages/components/src/component/table/FluxTableHeader.vue
+++ b/packages/components/src/component/table/FluxTableHeader.vue
@@ -19,6 +19,7 @@
                 <button
                     :class="$style.tableSort"
                     :aria-label="translate('flux.sort')"
+                    data-flux-copy="none"
                     type="button"
                     @click="open">
                     <FluxIcon
@@ -66,6 +67,7 @@
             :aria-valuemax="maxWidth"
             :aria-valuemin="minWidth ?? MIN_RESIZE_WIDTH"
             :aria-valuenow="resizedWidth ?? width"
+            data-flux-copy="none"
             type="button"
             @dblclick="resetWidth"
             @keydown="onResizeKeyDown"/>

--- a/packages/components/src/component/table/FluxTableRow.vue
+++ b/packages/components/src/component/table/FluxTableRow.vue
@@ -15,6 +15,7 @@
             color === 'warning' && $style.tableRowWarning
         )"
         role="row"
+        :aria-selected="isSelected"
         :tabindex="tabindex"
         @click="onClick"
         @focusin="onFocusin"

--- a/packages/components/src/component/table/FluxTableRow.vue
+++ b/packages/components/src/component/table/FluxTableRow.vue
@@ -31,7 +31,7 @@
     import { clsx } from 'clsx';
     import { computed, onUnmounted, useTemplateRef, type VNode, watch } from 'vue';
     import { useTableInjection } from '~flux/components/composable';
-    import { resolveColumnIndex } from '~flux/components/composable/private';
+    import { CELL_SELECTOR, HEADER_SELECTOR, INTERACTIVE_SELECTOR, resolveColumnIndex } from '~flux/components/composable/private';
     import $style from '~flux/components/css/component/Table.module.scss';
 
     const emit = defineEmits<{
@@ -51,8 +51,6 @@
     defineSlots<{
         default(): VNode[];
     }>();
-
-    const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
 
     const row = useTemplateRef('row');
 
@@ -100,7 +98,7 @@
             return;
         }
 
-        const cell = target?.closest('[role="cell"], [role="columnheader"]');
+        const cell = target?.closest(`${CELL_SELECTOR}, ${HEADER_SELECTOR}`);
 
         emit('rowClick', resolveColumnIndex(cell), event);
     }
@@ -123,7 +121,7 @@
         event.preventDefault();
 
         const current = event.currentTarget as HTMLElement;
-        const rows = Array.from(current.closest('[role="table"]')?.querySelectorAll<HTMLElement>('[role="row"][tabindex]') ?? []);
+        const rows = Array.from(current.closest('[role="table"], [role="grid"]')?.querySelectorAll<HTMLElement>('[role="row"][tabindex]') ?? []);
         const index = rows.indexOf(current);
 
         if (index === -1) {

--- a/packages/components/src/component/table/FluxTableRow.vue
+++ b/packages/components/src/component/table/FluxTableRow.vue
@@ -31,7 +31,7 @@
     import { clsx } from 'clsx';
     import { computed, onUnmounted, useTemplateRef, type VNode, watch } from 'vue';
     import { useTableInjection } from '~flux/components/composable';
-    import { CELL_SELECTOR, HEADER_SELECTOR, INTERACTIVE_SELECTOR, resolveColumnIndex } from '~flux/components/composable/private';
+    import { ANY_CELL_SELECTOR, INTERACTIVE_SELECTOR, resolveColumnIndex } from '~flux/components/composable/private';
     import $style from '~flux/components/css/component/Table.module.scss';
 
     const emit = defineEmits<{
@@ -98,7 +98,7 @@
             return;
         }
 
-        const cell = target?.closest(`${CELL_SELECTOR}, ${HEADER_SELECTOR}`);
+        const cell = target?.closest(ANY_CELL_SELECTOR);
 
         emit('rowClick', resolveColumnIndex(cell), event);
     }

--- a/packages/components/src/component/table/FluxTableTreeCell.vue
+++ b/packages/components/src/component/table/FluxTableTreeCell.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="$style.tableTreeCell"
-        role="cell">
+        :role="cellRole">
         <div
             ref="branch"
             :class="$style.treeBranch"
@@ -72,7 +72,7 @@
     const branch = useTemplateRef('branch');
     const translate = useTranslate();
 
-    const {registerTreeNode} = useTableInjection();
+    const {cellRole, registerTreeNode} = useTableInjection();
 
     const isFluxColor = computed(() => FLUX_COLORS.includes(color as FluxColor));
     const markerColorClass = computed(() => isFluxColor.value ? MARKER_COLOR_CLASS[color as FluxColor] : $style.treeMarkerCustom);

--- a/packages/components/src/composable/private/index.ts
+++ b/packages/components/src/composable/private/index.ts
@@ -11,7 +11,7 @@ export { MENU_PANE_SELECTOR, onMenuPaneKeydown } from './useMenuPane';
 export { useSplitView, type SplitViewPane, type UseSplitViewOptions, type UseSplitViewReturn } from './useSplitView';
 export { useTableCellSelection, type UseTableCellSelectionReturn } from './useTableCellSelection';
 export { useTableClipboard, type UseTableClipboardOptions, type UseTableClipboardReturn } from './useTableClipboard';
-export { countColumns, getColumnSpan, resolveColumnIndex, useTableColumnIndex } from './useTableColumnIndex';
+export { CELL_SELECTOR, countColumns, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, resolveColumnIndex, ROW_SELECTOR, useTableColumnIndex } from './useTableColumnIndex';
 export { useTableTree, TREE_STEP, TREE_MARKER_SIZE } from './useTableTree';
 export { useTimeline } from './useTimeline';
 export { default as useTranslate } from './useTranslate';

--- a/packages/components/src/composable/private/index.ts
+++ b/packages/components/src/composable/private/index.ts
@@ -9,6 +9,7 @@ export { findKanbanSwimlaneTarget, toKanbanCellId, useKanbanLayout, useKanbanLay
 export { default as useMenuFlyout, useMenuFlyoutContext, useMenuFlyoutProvider, type UseMenuFlyoutOptions, type UseMenuFlyoutProviderOptions, type UseMenuFlyoutReturn } from './useMenuFlyout';
 export { MENU_PANE_SELECTOR, onMenuPaneKeydown } from './useMenuPane';
 export { useSplitView, type SplitViewPane, type UseSplitViewOptions, type UseSplitViewReturn } from './useSplitView';
+export { useTableClipboard, type UseTableClipboardReturn } from './useTableClipboard';
 export { countColumns, getColumnSpan, resolveColumnIndex, useTableColumnIndex } from './useTableColumnIndex';
 export { useTableTree, TREE_STEP, TREE_MARKER_SIZE } from './useTableTree';
 export { useTimeline } from './useTimeline';

--- a/packages/components/src/composable/private/index.ts
+++ b/packages/components/src/composable/private/index.ts
@@ -11,7 +11,7 @@ export { MENU_PANE_SELECTOR, onMenuPaneKeydown } from './useMenuPane';
 export { useSplitView, type SplitViewPane, type UseSplitViewOptions, type UseSplitViewReturn } from './useSplitView';
 export { useTableCellSelection, type UseTableCellSelectionReturn } from './useTableCellSelection';
 export { useTableClipboard, type UseTableClipboardOptions, type UseTableClipboardReturn } from './useTableClipboard';
-export { CELL_SELECTOR, countColumns, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, resolveColumnIndex, ROW_SELECTOR, useTableColumnIndex } from './useTableColumnIndex';
+export { ANY_CELL_SELECTOR, CELL_SELECTOR, countColumns, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, resolveColumnIndex, ROW_SELECTOR, useTableColumnIndex } from './useTableColumnIndex';
 export { useTableTree, TREE_STEP, TREE_MARKER_SIZE } from './useTableTree';
 export { useTimeline } from './useTimeline';
 export { default as useTranslate } from './useTranslate';

--- a/packages/components/src/composable/private/index.ts
+++ b/packages/components/src/composable/private/index.ts
@@ -9,7 +9,8 @@ export { findKanbanSwimlaneTarget, toKanbanCellId, useKanbanLayout, useKanbanLay
 export { default as useMenuFlyout, useMenuFlyoutContext, useMenuFlyoutProvider, type UseMenuFlyoutOptions, type UseMenuFlyoutProviderOptions, type UseMenuFlyoutReturn } from './useMenuFlyout';
 export { MENU_PANE_SELECTOR, onMenuPaneKeydown } from './useMenuPane';
 export { useSplitView, type SplitViewPane, type UseSplitViewOptions, type UseSplitViewReturn } from './useSplitView';
-export { useTableClipboard, type UseTableClipboardReturn } from './useTableClipboard';
+export { useTableCellSelection, type UseTableCellSelectionReturn } from './useTableCellSelection';
+export { useTableClipboard, type UseTableClipboardOptions, type UseTableClipboardReturn } from './useTableClipboard';
 export { countColumns, getColumnSpan, resolveColumnIndex, useTableColumnIndex } from './useTableColumnIndex';
 export { useTableTree, TREE_STEP, TREE_MARKER_SIZE } from './useTableTree';
 export { useTimeline } from './useTimeline';

--- a/packages/components/src/composable/private/useTableCellSelection.ts
+++ b/packages/components/src/composable/private/useTableCellSelection.ts
@@ -2,7 +2,7 @@ import { useEventListener, useMutationObserver } from '@basmilius/common';
 import { clamp } from '@basmilius/utils';
 import { isSSR } from '@flux-ui/internals';
 import { type Ref, ref, unref, useId, watch } from 'vue';
-import { CELL_SELECTOR, getColumnSpan, getRowSpan, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
+import { CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
 
 export type UseTableCellSelectionReturn = {
     readonly activeCellId: Readonly<Ref<string | undefined>>;
@@ -10,6 +10,8 @@ export type UseTableCellSelectionReturn = {
     clear(): void;
 
     getSelectedCells(): ReadonlySet<HTMLElement>;
+
+    getSelectedHeaders(): HTMLElement[];
 };
 
 type GridCell = {
@@ -23,6 +25,7 @@ type GridCell = {
 type Grid = {
     readonly at: ReadonlyMap<string, GridCell>;
     readonly columnCount: number;
+    readonly firstDataRow: number;
     readonly positions: ReadonlyMap<HTMLElement, Position>;
     readonly rowCount: number;
 };
@@ -33,29 +36,40 @@ type Position = {
 };
 
 const ACTIVE_ATTRIBUTE = 'data-flux-active';
+const ANY_CELL_SELECTOR = `${CELL_SELECTOR}, ${HEADER_SELECTOR}`;
+const EXCLUDED_SELECTOR = '[data-flux-copy="none"]';
 const SELECTED_ATTRIBUTE = 'data-flux-selected';
 
-const EMPTY_GRID: Grid = {at: new Map(), columnCount: 0, positions: new Map(), rowCount: 0};
+const EMPTY_GRID: Grid = {at: new Map(), columnCount: 0, firstDataRow: 0, positions: new Map(), rowCount: 0};
 
 function toKey(row: number, column: number): string {
     return `${row}:${column}`;
 }
 
+// The header row is row 0 of the grid, which is what makes a click on a header
+// mean "this column, header included" rather than a case of its own.
 function buildGrid(container: HTMLElement | null): Grid {
     if (!container) {
         return EMPTY_GRID;
     }
 
-    const rows = Array.from(container.querySelectorAll<HTMLElement>(ROW_SELECTOR)).filter(isVisibleRow);
+    const rows = Array.from(container.querySelectorAll<HTMLElement>(ROW_SELECTOR))
+        .filter(row => isVisibleRow(row) && !row.matches(EXCLUDED_SELECTOR));
+
     const at = new Map<string, GridCell>();
     const positions = new Map<HTMLElement, Position>();
     let columnCount = 0;
+    let firstDataRow = 0;
 
     rows.forEach((row, rowIndex) => {
         let column = 0;
 
+        if (row.querySelector(HEADER_SELECTOR)) {
+            firstDataRow = rowIndex + 1;
+        }
+
         for (const child of row.children) {
-            if (!child.matches(CELL_SELECTOR)) {
+            if (!child.matches(ANY_CELL_SELECTOR) || child.matches(EXCLUDED_SELECTOR)) {
                 continue;
             }
 
@@ -86,7 +100,7 @@ function buildGrid(container: HTMLElement | null): Grid {
         columnCount = Math.max(columnCount, column);
     });
 
-    return {at, columnCount, positions, rowCount: rows.length};
+    return {at, columnCount, firstDataRow, positions, rowCount: rows.length};
 }
 
 /**
@@ -99,7 +113,7 @@ function buildGrid(container: HTMLElement | null): Grid {
  * rendering it, so extending it by one column touches the cells that changed
  * instead of patching every row through Vue.
  */
-export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, container: Readonly<Ref<HTMLElement | null>>, isEnabled: Readonly<Ref<boolean>>): UseTableCellSelectionReturn {
+export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, isEnabled: Readonly<Ref<boolean>>): UseTableCellSelectionReturn {
     const activeCellId = ref<string | undefined>();
     const idPrefix = useId();
 
@@ -110,11 +124,12 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
     let painted = new Map<HTMLElement, string>();
     let activeCell: HTMLElement | null = null;
     let isDragging = false;
+    let isColumnDrag = false;
     let idCounter = 0;
 
     function refresh(): void {
         if (isMapStale) {
-            map = buildGrid(unref(container));
+            map = buildGrid(unref(grid));
             isMapStale = false;
         }
     }
@@ -231,7 +246,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
     }
 
     function resolvePosition(target: Element | null): Position | null {
-        const element = target?.closest(CELL_SELECTOR) as HTMLElement | null;
+        const element = target?.closest(ANY_CELL_SELECTOR) as HTMLElement | null;
 
         return element ? map.positions.get(element) ?? null : null;
     }
@@ -252,6 +267,16 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
 
     function selectLastCell(isExtending: boolean): void {
         select({column: Math.max(map.columnCount - 1, 0), row: Math.max(map.rowCount - 1, 0)}, isExtending);
+    }
+
+    // A header claims its whole column, itself included, so the block a spreadsheet
+    // gives you for a column click is the block that gets copied.
+    function selectColumn(column: number, isExtending: boolean): void {
+        anchor = {column: isExtending && anchor ? anchor.column : column, row: 0};
+        focus = {column, row: Math.max(map.rowCount - 1, 0)};
+
+        paint();
+        markActive({column, row: 0});
     }
 
     function onPointerDown(evt: PointerEvent): void {
@@ -285,7 +310,14 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
         // The table is the tab stop, so the pointer must not hand focus to a cell,
         // and must not start a text selection the cell rectangle would fight with.
         evt.preventDefault();
-        select(position, evt.shiftKey);
+
+        isColumnDrag = !!target?.closest(HEADER_SELECTOR);
+
+        if (isColumnDrag) {
+            selectColumn(position.column, evt.shiftKey);
+        } else {
+            select(position, evt.shiftKey);
+        }
     }
 
     function onPointerMove(evt: PointerEvent): void {
@@ -295,7 +327,13 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
 
         const position = resolvePosition(document.elementFromPoint(evt.clientX, evt.clientY));
 
-        if (position) {
+        if (!position) {
+            return;
+        }
+
+        if (isColumnDrag) {
+            selectColumn(position.column, true);
+        } else {
             select(position, true);
         }
     }
@@ -368,7 +406,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
     // Rows the table replaces leave the selection holding detached elements, which
     // would copy nothing and point aria-activedescendant at an id that is gone. Only
     // rows count: a cell rerendering its own text leaves the map intact.
-    useMutationObserver(container, mutations => {
+    useMutationObserver(grid, mutations => {
         if (!mutations.some(mutation => holdsRow(mutation.addedNodes) || holdsRow(mutation.removedNodes))) {
             return;
         }
@@ -401,7 +439,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
         }
 
         refresh();
-        select({column: 0, row: 0}, false);
+        select({column: 0, row: map.firstDataRow}, false);
     });
 
     useEventListener(grid, 'pointerdown', onPointerDown);
@@ -417,9 +455,37 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
         }
     });
 
+    // A rectangle taken from the body pastes as anonymous values, so the columns it
+    // covers hand over their headers too. Not when the selection holds them already,
+    // and not within a single row, which mirrors what a text selection copies.
+    function getSelectedHeaders(): HTMLElement[] {
+        if (!anchor || !focus) {
+            return [];
+        }
+
+        const rowStart = Math.min(anchor.row, focus.row);
+
+        if (rowStart < map.firstDataRow || rowStart === Math.max(anchor.row, focus.row)) {
+            return [];
+        }
+
+        const headers: HTMLElement[] = [];
+
+        for (let column = Math.min(anchor.column, focus.column); column <= Math.max(anchor.column, focus.column); column++) {
+            const header = map.at.get(toKey(0, column))?.element;
+
+            if (header?.matches(HEADER_SELECTOR) && !headers.includes(header)) {
+                headers.push(header);
+            }
+        }
+
+        return headers;
+    }
+
     return {
         activeCellId,
         clear,
+        getSelectedHeaders,
 
         getSelectedCells: () => new Set(painted.keys())
     };

--- a/packages/components/src/composable/private/useTableCellSelection.ts
+++ b/packages/components/src/composable/private/useTableCellSelection.ts
@@ -2,7 +2,7 @@ import { useEventListener, useMutationObserver } from '@basmilius/common';
 import { clamp } from '@basmilius/utils';
 import { isSSR } from '@flux-ui/internals';
 import { type Ref, ref, unref, useId, watch } from 'vue';
-import { CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
+import { ANY_CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
 
 export type UseTableCellSelectionReturn = {
     readonly activeCellId: Readonly<Ref<string | undefined>>;
@@ -36,7 +36,6 @@ type Position = {
 };
 
 const ACTIVE_ATTRIBUTE = 'data-flux-active';
-const ANY_CELL_SELECTOR = `${CELL_SELECTOR}, ${HEADER_SELECTOR}`;
 const EXCLUDED_SELECTOR = '[data-flux-copy="none"]';
 const SELECTED_ATTRIBUTE = 'data-flux-selected';
 
@@ -251,22 +250,35 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, i
         return element ? map.positions.get(element) ?? null : null;
     }
 
+    // A row covering fewer columns than the widest one leaves the grid with holes,
+    // and landing in one would drop both the outline and aria-activedescendant, so
+    // the nearest cell to the left is taken instead.
+    function selectAt(row: number, column: number, isExtending: boolean): void {
+        for (let candidate = column; candidate >= 0; candidate--) {
+            if (map.at.has(toKey(row, candidate))) {
+                select({column: candidate, row}, isExtending);
+                return;
+            }
+        }
+    }
+
     function moveBy(rowDelta: number, columnDelta: number, isExtending: boolean): void {
         const current = focus ?? anchor;
 
         if (!current) {
-            select({column: 0, row: 0}, false);
+            selectAt(0, 0, false);
             return;
         }
 
-        select({
-            column: clamp(current.column + columnDelta, 0, Math.max(map.columnCount - 1, 0)),
-            row: clamp(current.row + rowDelta, 0, Math.max(map.rowCount - 1, 0))
-        }, isExtending);
+        selectAt(
+            clamp(current.row + rowDelta, 0, Math.max(map.rowCount - 1, 0)),
+            clamp(current.column + columnDelta, 0, Math.max(map.columnCount - 1, 0)),
+            isExtending
+        );
     }
 
     function selectLastCell(isExtending: boolean): void {
-        select({column: Math.max(map.columnCount - 1, 0), row: Math.max(map.rowCount - 1, 0)}, isExtending);
+        selectAt(Math.max(map.rowCount - 1, 0), Math.max(map.columnCount - 1, 0), isExtending);
     }
 
     // A header claims its whole column, itself included, so the block a spreadsheet
@@ -325,6 +337,13 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, i
             return;
         }
 
+        // Pointer capture is optional, and without it a pointerup outside the table
+        // never reaches the grid, leaving the drag extending with no button held.
+        if (evt.buttons === 0 || !unref(isEnabled)) {
+            isDragging = false;
+            return;
+        }
+
         const position = resolvePosition(document.elementFromPoint(evt.clientX, evt.clientY));
 
         if (!position) {
@@ -345,7 +364,13 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, i
 
         const isModified = evt.ctrlKey || evt.metaKey;
 
+        // Only when there is something to clear: a table inside a dialog would
+        // otherwise swallow the Escape that closes it.
         if (evt.key === 'Escape') {
+            if (!anchor && !focus) {
+                return;
+            }
+
             evt.preventDefault();
             clear();
             return;
@@ -439,7 +464,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, i
         }
 
         refresh();
-        select({column: 0, row: map.firstDataRow}, false);
+        selectAt(map.firstDataRow, 0, false);
     });
 
     useEventListener(grid, 'pointerdown', onPointerDown);
@@ -451,6 +476,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, i
 
     watch(isEnabled, enabled => {
         if (!enabled) {
+            isDragging = false;
             clear();
         }
     });

--- a/packages/components/src/composable/private/useTableCellSelection.ts
+++ b/packages/components/src/composable/private/useTableCellSelection.ts
@@ -1,7 +1,8 @@
-import { useEventListener } from '@basmilius/common';
+import { useEventListener, useMutationObserver } from '@basmilius/common';
+import { clamp } from '@basmilius/utils';
 import { isSSR } from '@flux-ui/internals';
-import { computed, type Ref, ref, unref, useId, watch } from 'vue';
-import { getColumnSpan } from './useTableColumnIndex';
+import { type Ref, ref, unref, useId, watch } from 'vue';
+import { CELL_SELECTOR, getColumnSpan, getRowSpan, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
 
 export type UseTableCellSelectionReturn = {
     readonly activeCellId: Readonly<Ref<string | undefined>>;
@@ -32,9 +33,6 @@ type Position = {
 };
 
 const ACTIVE_ATTRIBUTE = 'data-flux-active';
-const CELL_SELECTOR = '[role="cell"], [role="gridcell"]';
-const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
-const ROW_SELECTOR = '[role="row"]';
 const SELECTED_ATTRIBUTE = 'data-flux-selected';
 
 const EMPTY_GRID: Grid = {at: new Map(), columnCount: 0, positions: new Map(), rowCount: 0};
@@ -43,29 +41,12 @@ function toKey(row: number, column: number): string {
     return `${row}:${column}`;
 }
 
-function getRowSpan(element: Element): number {
-    const span = Number.parseInt(element.getAttribute('aria-rowspan') ?? '', 10);
-
-    return Number.isNaN(span) || span < 1 ? 1 : span;
-}
-
-// A row is display: contents, which has no layout box, and checkVisibility() calls
-// anything without a box invisible. Only v-show hides a row, and that writes the
-// inline style this reads.
-function isVisibleRow(row: HTMLElement): boolean {
-    return row.style.display !== 'none';
-}
-
-// Every column a cell covers maps back to that cell, so a spanning cell is reached
-// from any of its columns and a cell below a rowspan resolves the column it really
-// sits in rather than the one its sibling index suggests.
 function buildGrid(container: HTMLElement | null): Grid {
     if (!container) {
         return EMPTY_GRID;
     }
 
     const rows = Array.from(container.querySelectorAll<HTMLElement>(ROW_SELECTOR)).filter(isVisibleRow);
-
     const at = new Map<string, GridCell>();
     const positions = new Map<HTMLElement, Position>();
     let columnCount = 0;
@@ -119,47 +100,39 @@ function buildGrid(container: HTMLElement | null): Grid {
  * instead of patching every row through Vue.
  */
 export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, container: Readonly<Ref<HTMLElement | null>>, isEnabled: Readonly<Ref<boolean>>): UseTableCellSelectionReturn {
-    const anchor = ref<Position | null>(null);
-    const focus = ref<Position | null>(null);
-
     const activeCellId = ref<string | undefined>();
     const idPrefix = useId();
 
     let map = EMPTY_GRID;
+    let isMapStale = true;
+    let anchor: Position | null = null;
+    let focus: Position | null = null;
     let painted = new Map<HTMLElement, string>();
     let activeCell: HTMLElement | null = null;
     let isDragging = false;
     let idCounter = 0;
 
-    const range = computed(() => {
-        const from = unref(anchor);
-        const to = unref(focus);
-
-        if (!from || !to) {
-            return null;
+    function refresh(): void {
+        if (isMapStale) {
+            map = buildGrid(unref(container));
+            isMapStale = false;
         }
+    }
 
-        return {
-            columnEnd: Math.max(from.column, to.column),
-            columnStart: Math.min(from.column, to.column),
-            rowEnd: Math.max(from.row, to.row),
-            rowStart: Math.min(from.row, to.row)
-        };
-    });
-
-    // The value names the sides of the rectangle a cell sits on, so the outline is
-    // drawn around the block as a whole rather than around every cell in it. A cell
-    // that spans past an edge still holds that edge.
     function resolveCells(): Map<HTMLElement, string> {
-        const bounds = unref(range);
         const cells = new Map<HTMLElement, string>();
 
-        if (!bounds) {
+        if (!anchor || !focus) {
             return cells;
         }
 
-        for (let row = bounds.rowStart; row <= bounds.rowEnd; row++) {
-            for (let column = bounds.columnStart; column <= bounds.columnEnd; column++) {
+        const columnEnd = Math.max(anchor.column, focus.column);
+        const columnStart = Math.min(anchor.column, focus.column);
+        const rowEnd = Math.max(anchor.row, focus.row);
+        const rowStart = Math.min(anchor.row, focus.row);
+
+        for (let row = rowStart; row <= rowEnd; row++) {
+            for (let column = columnStart; column <= columnEnd; column++) {
                 const cell = map.at.get(toKey(row, column));
 
                 if (!cell || cells.has(cell.element)) {
@@ -168,19 +141,19 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
 
                 const edges: string[] = [];
 
-                if (cell.rowStart <= bounds.rowStart) {
+                if (cell.rowStart <= rowStart) {
                     edges.push('top');
                 }
 
-                if (cell.rowEnd > bounds.rowEnd) {
+                if (cell.rowEnd > rowEnd) {
                     edges.push('bottom');
                 }
 
-                if (cell.columnStart <= bounds.columnStart) {
+                if (cell.columnStart <= columnStart) {
                     edges.push('left');
                 }
 
-                if (cell.columnEnd > bounds.columnEnd) {
+                if (cell.columnEnd > columnEnd) {
                     edges.push('right');
                 }
 
@@ -232,23 +205,26 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
 
         cell.setAttribute(ACTIVE_ATTRIBUTE, '');
         activeCellId.value = cell.id;
-        cell.scrollIntoView({block: 'nearest', inline: 'nearest'});
+
+        if (!isDragging) {
+            cell.scrollIntoView({block: 'nearest', inline: 'nearest'});
+        }
     }
 
     function clear(): void {
-        anchor.value = null;
-        focus.value = null;
+        anchor = null;
+        focus = null;
 
         paint();
         markActive(null);
     }
 
     function select(position: Position, isExtending: boolean): void {
-        if (!isExtending || !unref(anchor)) {
-            anchor.value = position;
+        if (!isExtending || !anchor) {
+            anchor = position;
         }
 
-        focus.value = position;
+        focus = position;
 
         paint();
         markActive(position);
@@ -261,7 +237,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
     }
 
     function moveBy(rowDelta: number, columnDelta: number, isExtending: boolean): void {
-        const current = unref(focus) ?? unref(anchor);
+        const current = focus ?? anchor;
 
         if (!current) {
             select({column: 0, row: 0}, false);
@@ -269,8 +245,8 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
         }
 
         select({
-            column: Math.min(Math.max(current.column + columnDelta, 0), Math.max(map.columnCount - 1, 0)),
-            row: Math.min(Math.max(current.row + rowDelta, 0), Math.max(map.rowCount - 1, 0))
+            column: clamp(current.column + columnDelta, 0, Math.max(map.columnCount - 1, 0)),
+            row: clamp(current.row + rowDelta, 0, Math.max(map.rowCount - 1, 0))
         }, isExtending);
     }
 
@@ -289,7 +265,7 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
             return;
         }
 
-        map = buildGrid(unref(container));
+        refresh();
 
         const position = resolvePosition(target);
 
@@ -297,19 +273,18 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
             return;
         }
 
-        // The table is the tab stop, so the pointer must not hand focus to a cell,
-        // and must not start a text selection the cell rectangle would fight with.
-        evt.preventDefault();
+        // Before focusing: the focus handler claims the first cell for a table that
+        // is tabbed into, which this click is about to answer itself.
+        isDragging = true;
 
         const gridElement = unref(grid);
-
-        // Before focusing: the focus handler below claims the first cell for a table
-        // that is tabbed into, which this click is about to answer itself.
-        isDragging = true;
 
         gridElement?.focus();
         gridElement?.setPointerCapture?.(evt.pointerId);
 
+        // The table is the tab stop, so the pointer must not hand focus to a cell,
+        // and must not start a text selection the cell rectangle would fight with.
+        evt.preventDefault();
         select(position, evt.shiftKey);
     }
 
@@ -330,9 +305,19 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
             return;
         }
 
-        map = buildGrid(unref(container));
-
         const isModified = evt.ctrlKey || evt.metaKey;
+
+        if (evt.key === 'Escape') {
+            evt.preventDefault();
+            clear();
+            return;
+        }
+
+        if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(evt.key) && !(isModified && evt.key.toLowerCase() === 'a')) {
+            return;
+        }
+
+        refresh();
 
         switch (evt.key) {
             case 'ArrowUp':
@@ -367,37 +352,33 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
                 }
                 break;
 
-            case 'a':
-            case 'A':
-                if (!isModified) {
-                    return;
-                }
-
-                anchor.value = {column: 0, row: 0};
+            default:
+                anchor = {column: 0, row: 0};
                 selectLastCell(true);
                 break;
-
-            case 'Escape':
-                clear();
-                break;
-
-            default:
-                return;
         }
 
         evt.preventDefault();
     }
 
-    // Tabbing into the table has to land somewhere visible, and a grid says where it
-    // is through aria-activedescendant, which needs a cell to point at.
-    useEventListener(grid, 'focus', () => {
-        if (!unref(isEnabled) || isDragging || unref(focus)) {
+    function holdsRow(nodes: NodeList): boolean {
+        return Array.from(nodes).some(node => node instanceof HTMLElement && (node.matches(ROW_SELECTOR) || !!node.querySelector(ROW_SELECTOR)));
+    }
+
+    // Rows the table replaces leave the selection holding detached elements, which
+    // would copy nothing and point aria-activedescendant at an id that is gone. Only
+    // rows count: a cell rerendering its own text leaves the map intact.
+    useMutationObserver(container, mutations => {
+        if (!mutations.some(mutation => holdsRow(mutation.addedNodes) || holdsRow(mutation.removedNodes))) {
             return;
         }
 
-        map = buildGrid(unref(container));
-        select({column: 0, row: 0}, false);
-    });
+        isMapStale = true;
+
+        if (anchor) {
+            clear();
+        }
+    }, {childList: true, subtree: true});
 
     // On click rather than pointerdown, and without capture, so a copy button of the
     // consumer's own runs its handler first: it reads the selection synchronously,
@@ -405,17 +386,28 @@ export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, c
     useEventListener(() => isSSR ? null : document, 'click', evt => {
         const gridElement = unref(grid);
 
-        if (!unref(isEnabled) || !unref(focus) || !gridElement || gridElement.contains(evt.target as Node)) {
+        if (!unref(isEnabled) || !focus || !gridElement || gridElement.contains(evt.target as Node)) {
             return;
         }
 
         clear();
     });
 
+    // Tabbing into the table has to land somewhere visible, and a grid says where it
+    // is through aria-activedescendant, which needs a cell to point at.
+    useEventListener(grid, 'focus', () => {
+        if (!unref(isEnabled) || isDragging || focus) {
+            return;
+        }
+
+        refresh();
+        select({column: 0, row: 0}, false);
+    });
+
     useEventListener(grid, 'pointerdown', onPointerDown);
     useEventListener(grid, 'pointermove', onPointerMove);
     useEventListener(grid, 'keydown', onKeyDown);
-    useEventListener(grid, 'lostpointercapture', () => {
+    useEventListener(grid, ['lostpointercapture', 'pointerup', 'pointercancel'], () => {
         isDragging = false;
     });
 

--- a/packages/components/src/composable/private/useTableCellSelection.ts
+++ b/packages/components/src/composable/private/useTableCellSelection.ts
@@ -1,0 +1,434 @@
+import { useEventListener } from '@basmilius/common';
+import { isSSR } from '@flux-ui/internals';
+import { computed, type Ref, ref, unref, useId, watch } from 'vue';
+import { getColumnSpan } from './useTableColumnIndex';
+
+export type UseTableCellSelectionReturn = {
+    readonly activeCellId: Readonly<Ref<string | undefined>>;
+
+    clear(): void;
+
+    getSelectedCells(): ReadonlySet<HTMLElement>;
+};
+
+type GridCell = {
+    readonly columnEnd: number;
+    readonly columnStart: number;
+    readonly element: HTMLElement;
+    readonly rowEnd: number;
+    readonly rowStart: number;
+};
+
+type Grid = {
+    readonly at: ReadonlyMap<string, GridCell>;
+    readonly columnCount: number;
+    readonly positions: ReadonlyMap<HTMLElement, Position>;
+    readonly rowCount: number;
+};
+
+type Position = {
+    readonly column: number;
+    readonly row: number;
+};
+
+const ACTIVE_ATTRIBUTE = 'data-flux-active';
+const CELL_SELECTOR = '[role="cell"], [role="gridcell"]';
+const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
+const ROW_SELECTOR = '[role="row"]';
+const SELECTED_ATTRIBUTE = 'data-flux-selected';
+
+const EMPTY_GRID: Grid = {at: new Map(), columnCount: 0, positions: new Map(), rowCount: 0};
+
+function toKey(row: number, column: number): string {
+    return `${row}:${column}`;
+}
+
+function getRowSpan(element: Element): number {
+    const span = Number.parseInt(element.getAttribute('aria-rowspan') ?? '', 10);
+
+    return Number.isNaN(span) || span < 1 ? 1 : span;
+}
+
+// A row is display: contents, which has no layout box, and checkVisibility() calls
+// anything without a box invisible. Only v-show hides a row, and that writes the
+// inline style this reads.
+function isVisibleRow(row: HTMLElement): boolean {
+    return row.style.display !== 'none';
+}
+
+// Every column a cell covers maps back to that cell, so a spanning cell is reached
+// from any of its columns and a cell below a rowspan resolves the column it really
+// sits in rather than the one its sibling index suggests.
+function buildGrid(container: HTMLElement | null): Grid {
+    if (!container) {
+        return EMPTY_GRID;
+    }
+
+    const rows = Array.from(container.querySelectorAll<HTMLElement>(ROW_SELECTOR)).filter(isVisibleRow);
+
+    const at = new Map<string, GridCell>();
+    const positions = new Map<HTMLElement, Position>();
+    let columnCount = 0;
+
+    rows.forEach((row, rowIndex) => {
+        let column = 0;
+
+        for (const child of row.children) {
+            if (!child.matches(CELL_SELECTOR)) {
+                continue;
+            }
+
+            while (at.has(toKey(rowIndex, column))) {
+                column++;
+            }
+
+            const element = child as HTMLElement;
+            const columnSpan = getColumnSpan(child);
+            const cell: GridCell = {
+                columnEnd: column + columnSpan,
+                columnStart: column,
+                element,
+                rowEnd: rowIndex + getRowSpan(child),
+                rowStart: rowIndex
+            };
+
+            for (let covered = cell.rowStart; covered < cell.rowEnd; covered++) {
+                for (let span = cell.columnStart; span < cell.columnEnd; span++) {
+                    at.set(toKey(covered, span), cell);
+                }
+            }
+
+            positions.set(element, {column: cell.columnStart, row: cell.rowStart});
+            column += columnSpan;
+        }
+
+        columnCount = Math.max(columnCount, column);
+    });
+
+    return {at, columnCount, positions, rowCount: rows.length};
+}
+
+/**
+ * Spreadsheet-style cell selection over the table body: a rectangle of cells,
+ * dragged with the pointer or walked with the arrow keys. The table itself is the
+ * single tab stop and points at the active cell through `aria-activedescendant`,
+ * which keeps a thousand-cell table to one focusable element.
+ *
+ * The selection is painted by setting attributes on the cells rather than by
+ * rendering it, so extending it by one column touches the cells that changed
+ * instead of patching every row through Vue.
+ */
+export function useTableCellSelection(grid: Readonly<Ref<HTMLElement | null>>, container: Readonly<Ref<HTMLElement | null>>, isEnabled: Readonly<Ref<boolean>>): UseTableCellSelectionReturn {
+    const anchor = ref<Position | null>(null);
+    const focus = ref<Position | null>(null);
+
+    const activeCellId = ref<string | undefined>();
+    const idPrefix = useId();
+
+    let map = EMPTY_GRID;
+    let painted = new Map<HTMLElement, string>();
+    let activeCell: HTMLElement | null = null;
+    let isDragging = false;
+    let idCounter = 0;
+
+    const range = computed(() => {
+        const from = unref(anchor);
+        const to = unref(focus);
+
+        if (!from || !to) {
+            return null;
+        }
+
+        return {
+            columnEnd: Math.max(from.column, to.column),
+            columnStart: Math.min(from.column, to.column),
+            rowEnd: Math.max(from.row, to.row),
+            rowStart: Math.min(from.row, to.row)
+        };
+    });
+
+    // The value names the sides of the rectangle a cell sits on, so the outline is
+    // drawn around the block as a whole rather than around every cell in it. A cell
+    // that spans past an edge still holds that edge.
+    function resolveCells(): Map<HTMLElement, string> {
+        const bounds = unref(range);
+        const cells = new Map<HTMLElement, string>();
+
+        if (!bounds) {
+            return cells;
+        }
+
+        for (let row = bounds.rowStart; row <= bounds.rowEnd; row++) {
+            for (let column = bounds.columnStart; column <= bounds.columnEnd; column++) {
+                const cell = map.at.get(toKey(row, column));
+
+                if (!cell || cells.has(cell.element)) {
+                    continue;
+                }
+
+                const edges: string[] = [];
+
+                if (cell.rowStart <= bounds.rowStart) {
+                    edges.push('top');
+                }
+
+                if (cell.rowEnd > bounds.rowEnd) {
+                    edges.push('bottom');
+                }
+
+                if (cell.columnStart <= bounds.columnStart) {
+                    edges.push('left');
+                }
+
+                if (cell.columnEnd > bounds.columnEnd) {
+                    edges.push('right');
+                }
+
+                cells.set(cell.element, edges.join(' '));
+            }
+        }
+
+        return cells;
+    }
+
+    function paint(): void {
+        const cells = resolveCells();
+
+        for (const element of painted.keys()) {
+            if (!cells.has(element)) {
+                element.removeAttribute(SELECTED_ATTRIBUTE);
+                element.removeAttribute('aria-selected');
+            }
+        }
+
+        for (const [element, edges] of cells) {
+            if (painted.get(element) !== edges) {
+                element.setAttribute(SELECTED_ATTRIBUTE, edges);
+                element.setAttribute('aria-selected', 'true');
+            }
+        }
+
+        painted = cells;
+    }
+
+    function markActive(position: Position | null): void {
+        const cell = position ? map.at.get(toKey(position.row, position.column))?.element ?? null : null;
+
+        if (cell === activeCell) {
+            return;
+        }
+
+        activeCell?.removeAttribute(ACTIVE_ATTRIBUTE);
+        activeCell = cell;
+
+        if (!cell) {
+            activeCellId.value = undefined;
+            return;
+        }
+
+        if (!cell.id) {
+            cell.id = `${idPrefix}-cell-${++idCounter}`;
+        }
+
+        cell.setAttribute(ACTIVE_ATTRIBUTE, '');
+        activeCellId.value = cell.id;
+        cell.scrollIntoView({block: 'nearest', inline: 'nearest'});
+    }
+
+    function clear(): void {
+        anchor.value = null;
+        focus.value = null;
+
+        paint();
+        markActive(null);
+    }
+
+    function select(position: Position, isExtending: boolean): void {
+        if (!isExtending || !unref(anchor)) {
+            anchor.value = position;
+        }
+
+        focus.value = position;
+
+        paint();
+        markActive(position);
+    }
+
+    function resolvePosition(target: Element | null): Position | null {
+        const element = target?.closest(CELL_SELECTOR) as HTMLElement | null;
+
+        return element ? map.positions.get(element) ?? null : null;
+    }
+
+    function moveBy(rowDelta: number, columnDelta: number, isExtending: boolean): void {
+        const current = unref(focus) ?? unref(anchor);
+
+        if (!current) {
+            select({column: 0, row: 0}, false);
+            return;
+        }
+
+        select({
+            column: Math.min(Math.max(current.column + columnDelta, 0), Math.max(map.columnCount - 1, 0)),
+            row: Math.min(Math.max(current.row + rowDelta, 0), Math.max(map.rowCount - 1, 0))
+        }, isExtending);
+    }
+
+    function selectLastCell(isExtending: boolean): void {
+        select({column: Math.max(map.columnCount - 1, 0), row: Math.max(map.rowCount - 1, 0)}, isExtending);
+    }
+
+    function onPointerDown(evt: PointerEvent): void {
+        if (!unref(isEnabled) || evt.button !== 0) {
+            return;
+        }
+
+        const target = evt.target as Element | null;
+
+        if (target?.closest(INTERACTIVE_SELECTOR)) {
+            return;
+        }
+
+        map = buildGrid(unref(container));
+
+        const position = resolvePosition(target);
+
+        if (!position) {
+            return;
+        }
+
+        // The table is the tab stop, so the pointer must not hand focus to a cell,
+        // and must not start a text selection the cell rectangle would fight with.
+        evt.preventDefault();
+
+        const gridElement = unref(grid);
+
+        // Before focusing: the focus handler below claims the first cell for a table
+        // that is tabbed into, which this click is about to answer itself.
+        isDragging = true;
+
+        gridElement?.focus();
+        gridElement?.setPointerCapture?.(evt.pointerId);
+
+        select(position, evt.shiftKey);
+    }
+
+    function onPointerMove(evt: PointerEvent): void {
+        if (!isDragging) {
+            return;
+        }
+
+        const position = resolvePosition(document.elementFromPoint(evt.clientX, evt.clientY));
+
+        if (position) {
+            select(position, true);
+        }
+    }
+
+    function onKeyDown(evt: KeyboardEvent): void {
+        if (!unref(isEnabled) || (evt.target as Element | null)?.closest(INTERACTIVE_SELECTOR)) {
+            return;
+        }
+
+        map = buildGrid(unref(container));
+
+        const isModified = evt.ctrlKey || evt.metaKey;
+
+        switch (evt.key) {
+            case 'ArrowUp':
+                moveBy(isModified ? -map.rowCount : -1, 0, evt.shiftKey);
+                break;
+
+            case 'ArrowDown':
+                moveBy(isModified ? map.rowCount : 1, 0, evt.shiftKey);
+                break;
+
+            case 'ArrowLeft':
+                moveBy(0, isModified ? -map.columnCount : -1, evt.shiftKey);
+                break;
+
+            case 'ArrowRight':
+                moveBy(0, isModified ? map.columnCount : 1, evt.shiftKey);
+                break;
+
+            case 'Home':
+                if (isModified) {
+                    select({column: 0, row: 0}, evt.shiftKey);
+                } else {
+                    moveBy(0, -map.columnCount, evt.shiftKey);
+                }
+                break;
+
+            case 'End':
+                if (isModified) {
+                    selectLastCell(evt.shiftKey);
+                } else {
+                    moveBy(0, map.columnCount, evt.shiftKey);
+                }
+                break;
+
+            case 'a':
+            case 'A':
+                if (!isModified) {
+                    return;
+                }
+
+                anchor.value = {column: 0, row: 0};
+                selectLastCell(true);
+                break;
+
+            case 'Escape':
+                clear();
+                break;
+
+            default:
+                return;
+        }
+
+        evt.preventDefault();
+    }
+
+    // Tabbing into the table has to land somewhere visible, and a grid says where it
+    // is through aria-activedescendant, which needs a cell to point at.
+    useEventListener(grid, 'focus', () => {
+        if (!unref(isEnabled) || isDragging || unref(focus)) {
+            return;
+        }
+
+        map = buildGrid(unref(container));
+        select({column: 0, row: 0}, false);
+    });
+
+    // On click rather than pointerdown, and without capture, so a copy button of the
+    // consumer's own runs its handler first: it reads the selection synchronously,
+    // and only then is the selection dropped.
+    useEventListener(() => isSSR ? null : document, 'click', evt => {
+        const gridElement = unref(grid);
+
+        if (!unref(isEnabled) || !unref(focus) || !gridElement || gridElement.contains(evt.target as Node)) {
+            return;
+        }
+
+        clear();
+    });
+
+    useEventListener(grid, 'pointerdown', onPointerDown);
+    useEventListener(grid, 'pointermove', onPointerMove);
+    useEventListener(grid, 'keydown', onKeyDown);
+    useEventListener(grid, 'lostpointercapture', () => {
+        isDragging = false;
+    });
+
+    watch(isEnabled, enabled => {
+        if (!enabled) {
+            clear();
+        }
+    });
+
+    return {
+        activeCellId,
+        clear,
+
+        getSelectedCells: () => new Set(painted.keys())
+    };
+}

--- a/packages/components/src/composable/private/useTableClipboard.ts
+++ b/packages/components/src/composable/private/useTableClipboard.ts
@@ -1,6 +1,6 @@
 import { useEventListener } from '@basmilius/common';
 import { type Ref, unref } from 'vue';
-import { CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
+import { ANY_CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
 
 export type UseTableClipboardOptions = {
     getSelectedCells?(): ReadonlySet<HTMLElement>;
@@ -24,7 +24,6 @@ type CopiedRow = {
     readonly isFullWidth: boolean;
 };
 
-const ANY_CELL_SELECTOR = `${CELL_SELECTOR}, ${HEADER_SELECTOR}`;
 const EXCLUDED_SELECTOR = '[data-flux-copy="none"]';
 const VALUE_ATTRIBUTE = 'data-flux-copy-value';
 
@@ -71,8 +70,20 @@ function readValue(cell: HTMLElement): string {
     const parts: string[] = [];
 
     while (walker.nextNode()) {
-        if (walker.currentNode.nodeType === Node.TEXT_NODE) {
-            parts.push(walker.currentNode.nodeValue ?? '');
+        const node = walker.currentNode;
+
+        if (node.nodeType === Node.TEXT_NODE) {
+            parts.push(node.nodeValue ?? '');
+            continue;
+        }
+
+        // innerText breaks the line between two block boxes, and this path has to
+        // agree with it or the same cell copies differently once it holds an
+        // excluded subtree.
+        const {display} = getComputedStyle(node as HTMLElement);
+
+        if (display !== 'contents' && !display.startsWith('inline')) {
+            parts.push(' ');
         }
     }
 
@@ -102,7 +113,7 @@ function normalize(rows: CopiedRow[]): CopiedRow[] {
         .filter(row => !row.isFullWidth)
         .map(row => row.cells.reduce((total, cell) => total + cell.colspan, 0)));
 
-    return rows.map(row => row.isFullWidth ? {...row, cells: [{...row.cells[0], colspan: width}]} : row);
+    return rows.map(row => row.isFullWidth && row.cells.length > 0 ? {...row, cells: [{...row.cells[0], colspan: width}]} : row);
 }
 
 function collectRows(baseElement: HTMLElement): HTMLElement[] {
@@ -195,25 +206,31 @@ function toHtml(rows: CopiedRow[]): string {
 }
 
 async function write(rows: CopiedRow[]): Promise<boolean> {
-    if (rows.length === 0 || !navigator.clipboard) {
+    if (rows.length === 0 || !navigator.clipboard || typeof ClipboardItem === 'undefined') {
         return false;
     }
 
-    await navigator.clipboard.write([
-        new ClipboardItem({
-            'text/html': new Blob([toHtml(rows)], {type: 'text/html'}),
-            'text/plain': new Blob([toText(rows)], {type: 'text/plain'})
-        })
-    ]);
+    // The shortcut copies without awaiting, so a denied permission has to come back
+    // as false rather than as an unhandled rejection.
+    try {
+        await navigator.clipboard.write([
+            new ClipboardItem({
+                'text/html': new Blob([toHtml(rows)], {type: 'text/html'}),
+                'text/plain': new Blob([toText(rows)], {type: 'text/plain'})
+            })
+        ]);
 
-    return true;
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 /**
  * Rebuilds the clipboard from the cells of a table. A grid of divs serializes as
  * one line per cell with nothing marking where a row ends, so a spreadsheet
  * receives a single column; both clipboard flavors are therefore written from the
- * table structure instead, tab separated and as real table markup.
+ * table structure instead, tab-separated and as real table markup.
  *
  * A cell states its own value with `data-flux-copy-value`. Anything carrying
  * `data-flux-copy="none"` is left out: a whole row or cell when the attribute sits

--- a/packages/components/src/composable/private/useTableClipboard.ts
+++ b/packages/components/src/composable/private/useTableClipboard.ts
@@ -4,6 +4,8 @@ import { CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_
 
 export type UseTableClipboardOptions = {
     getSelectedCells?(): ReadonlySet<HTMLElement>;
+
+    getSelectedHeaders?(): HTMLElement[];
 };
 
 export type UseTableClipboardReturn = {
@@ -114,10 +116,15 @@ function serializeRows(rows: HTMLElement[], isIncluded?: (cell: HTMLElement) => 
         .filter(row => row.cells.length > 0));
 }
 
-function serializeSelectedCells(baseElement: HTMLElement, cells: ReadonlySet<HTMLElement>): CopiedRow[] {
+function serializeSelectedCells(baseElement: HTMLElement, cells: ReadonlySet<HTMLElement>, headers: HTMLElement[]): CopiedRow[] {
     const rows = collectRows(baseElement).filter(row => Array.from(row.children).some(child => cells.has(child as HTMLElement)));
+    const headerRow = headers[0]?.parentElement;
 
-    return serializeRows(rows, cell => cells.has(cell));
+    if (headerRow) {
+        rows.unshift(headerRow as HTMLElement);
+    }
+
+    return serializeRows(rows, cell => cells.has(cell) || headers.includes(cell));
 }
 
 function withHeaderRow(baseElement: HTMLElement, rows: readonly HTMLElement[]): HTMLElement[] {
@@ -240,7 +247,7 @@ export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>, optio
         const cells = options?.getSelectedCells?.();
 
         if (cells?.size) {
-            const selected = serializeSelectedCells(baseElement, cells);
+            const selected = serializeSelectedCells(baseElement, cells, options?.getSelectedHeaders?.() ?? []);
 
             if (selected.length > 0) {
                 evt.preventDefault();
@@ -289,7 +296,7 @@ export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>, optio
         const cells = rows ? undefined : options?.getSelectedCells?.();
 
         if (cells?.size) {
-            return write(serializeSelectedCells(baseElement, cells));
+            return write(serializeSelectedCells(baseElement, cells, options?.getSelectedHeaders?.() ?? []));
         }
 
         return write(serializeRows(rows ? withHeaderRow(baseElement, rows) : collectRows(baseElement)));

--- a/packages/components/src/composable/private/useTableClipboard.ts
+++ b/packages/components/src/composable/private/useTableClipboard.ts
@@ -1,0 +1,240 @@
+import { useEventListener } from '@basmilius/common';
+import { type Ref, unref } from 'vue';
+import { getColumnSpan } from './useTableColumnIndex';
+
+export type UseTableClipboardReturn = {
+    copy(rows?: readonly HTMLElement[]): Promise<boolean>;
+};
+
+type CopiedCell = {
+    readonly colspan: number;
+    readonly isFullWidth: boolean;
+    readonly isHeader: boolean;
+    readonly rowspan: number;
+    readonly value: string;
+};
+
+const CELL_SELECTOR = '[role="cell"], [role="columnheader"]';
+const EXCLUDED_SELECTOR = '[data-flux-copy="none"]';
+const HEADER_SELECTOR = '[role="columnheader"]';
+const ROW_SELECTOR = '[role="row"]';
+const VALUE_ATTRIBUTE = 'data-flux-copy-value';
+
+function isExcluded(element: Element): boolean {
+    return element.matches(EXCLUDED_SELECTOR);
+}
+
+function collapse(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function getRowSpan(element: Element): number {
+    const span = Number.parseInt(element.getAttribute('aria-rowspan') ?? '', 10);
+
+    return Number.isNaN(span) || span < 1 ? 1 : span;
+}
+
+function readValue(cell: HTMLElement): string {
+    const value = cell.getAttribute(VALUE_ATTRIBUTE);
+
+    if (value !== null) {
+        return collapse(value);
+    }
+
+    // innerText is what a browser itself would copy: it honors line boxes and
+    // leaves out anything the layout hides, such as a collapsed group's rows.
+    if (!cell.querySelector(EXCLUDED_SELECTOR)) {
+        return collapse(cell.innerText);
+    }
+
+    const walker = document.createTreeWalker(cell, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+        acceptNode: node => node.nodeType === Node.ELEMENT_NODE && isExcluded(node as Element) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+    });
+
+    const parts: string[] = [];
+
+    while (walker.nextNode()) {
+        if (walker.currentNode.nodeType === Node.TEXT_NODE) {
+            parts.push(walker.currentNode.nodeValue ?? '');
+        }
+    }
+
+    return collapse(parts.join(''));
+}
+
+function serializeRow(row: HTMLElement, isIncluded?: (cell: HTMLElement) => boolean): CopiedCell[] {
+    const candidates = Array.from(row.children).filter(child => child.matches(CELL_SELECTOR) && !isExcluded(child)) as HTMLElement[];
+    const isFullWidth = candidates.length === 1;
+
+    return candidates
+        .filter(cell => !isIncluded || isIncluded(cell))
+        .map(cell => ({
+            colspan: getColumnSpan(cell),
+            isFullWidth,
+            isHeader: cell.matches(HEADER_SELECTOR),
+            rowspan: getRowSpan(cell),
+            value: readValue(cell)
+        }));
+}
+
+// A row of one cell spans the table: a group header, a section row, an expanded
+// row's detail. Its own colspan counts the columns that were left out, so it is
+// restated as the width that is actually being copied.
+function normalize(rows: CopiedCell[][]): CopiedCell[][] {
+    const widths = rows
+        .filter(cells => !isFullWidthRow(cells))
+        .map(cells => cells.reduce((total, cell) => total + cell.colspan, 0));
+
+    const width = Math.max(1, ...widths);
+
+    return rows.map(cells => isFullWidthRow(cells) ? [{...cells[0], colspan: width}] : cells);
+}
+
+function isFullWidthRow(cells: CopiedCell[]): boolean {
+    return cells.length === 1 && cells[0].isFullWidth;
+}
+
+function serializeRows(rows: HTMLElement[], isIncluded?: (cell: HTMLElement) => boolean): CopiedCell[][] {
+    return normalize(rows
+        .map(row => serializeRow(row, isIncluded))
+        .filter(cells => cells.length > 0));
+}
+
+function collectRows(baseElement: HTMLElement): HTMLElement[] {
+    return Array.from(baseElement.querySelectorAll<HTMLElement>(ROW_SELECTOR))
+        .filter(row => !isExcluded(row) && (row.checkVisibility?.() ?? true));
+}
+
+// Rows pasted without their column names land in a spreadsheet as anonymous
+// values, so whole rows are copied with the header row in front of them.
+function withHeaderRow(baseElement: HTMLElement, rows: readonly HTMLElement[]): HTMLElement[] {
+    if (rows.some(row => row.querySelector(HEADER_SELECTOR))) {
+        return Array.from(rows);
+    }
+
+    const header = baseElement.querySelector<HTMLElement>(`${ROW_SELECTOR}:has(${HEADER_SELECTOR})`);
+
+    return header ? [header, ...rows] : Array.from(rows);
+}
+
+function toText(rows: CopiedCell[][]): string {
+    return rows
+        .map(cells => cells
+            .flatMap(cell => [cell.value, ...Array.from({length: cell.colspan - 1}, () => '')])
+            .join('\t'))
+        .join('\n');
+}
+
+function toHtml(rows: CopiedCell[][]): string {
+    const markup = rows
+        .map(cells => {
+            const columns = cells
+                .map(cell => {
+                    const tag = cell.isHeader ? 'th' : 'td';
+                    const colspan = cell.colspan > 1 ? ` colspan="${cell.colspan}"` : '';
+                    const rowspan = cell.rowspan > 1 ? ` rowspan="${cell.rowspan}"` : '';
+
+                    return `<${tag}${colspan}${rowspan}>${escapeHtml(cell.value)}</${tag}>`;
+                })
+                .join('');
+
+            return `<tr>${columns}</tr>`;
+        })
+        .join('');
+
+    return `<table>${markup}</table>`;
+}
+
+async function write(rows: CopiedCell[][]): Promise<boolean> {
+    if (rows.length === 0) {
+        return false;
+    }
+
+    const text = toText(rows);
+
+    if (typeof ClipboardItem === 'undefined' || !navigator.clipboard?.write) {
+        if (!navigator.clipboard?.writeText) {
+            return false;
+        }
+
+        await navigator.clipboard.writeText(text);
+
+        return true;
+    }
+
+    await navigator.clipboard.write([
+        new ClipboardItem({
+            'text/html': new Blob([toHtml(rows)], {type: 'text/html'}),
+            'text/plain': new Blob([text], {type: 'text/plain'})
+        })
+    ]);
+
+    return true;
+}
+
+/**
+ * Rebuilds the clipboard from the cells of a table. A grid of divs serializes as
+ * one line per cell with nothing marking where a row ends, so a spreadsheet
+ * receives a single column; both clipboard flavors are therefore written from the
+ * table structure instead, tab separated and as real table markup.
+ *
+ * A cell states its own value with `data-flux-copy-value`, which is what lets a
+ * formatted date or amount paste as the value behind it. Anything carrying
+ * `data-flux-copy="none"` is left out: a whole row or cell when the attribute
+ * sits on it, and only that subtree's text when it sits inside a cell.
+ */
+export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>): UseTableClipboardReturn {
+    useEventListener(base, 'copy', evt => {
+        const baseElement = unref(base);
+        const selection = window.getSelection();
+
+        if (!baseElement || !evt.clipboardData || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+            return;
+        }
+
+        const range = selection.getRangeAt(0);
+        const touched = collectRows(baseElement).filter(row => range.intersectsNode(row));
+
+        if (touched.length === 0) {
+            return;
+        }
+
+        // A drag ends halfway through its first and last row, which would copy those
+        // two rows short of the ones in between. Reaching a second row is therefore
+        // read as wanting those rows whole, column headers included; staying within
+        // one row keeps to the cells that were dragged over, and staying within one
+        // cell is an ordinary text copy that is left alone.
+        const rows = touched.length > 1
+            ? serializeRows(withHeaderRow(baseElement, touched))
+            : normalize([serializeRow(touched[0], cell => range.intersectsNode(cell))]);
+
+        if (rows.length === 0 || (rows.length === 1 && rows[0].length < 2)) {
+            return;
+        }
+
+        evt.preventDefault();
+        evt.clipboardData.setData('text/plain', toText(rows));
+        evt.clipboardData.setData('text/html', toHtml(rows));
+    });
+
+    async function copy(rows?: readonly HTMLElement[]): Promise<boolean> {
+        const baseElement = unref(base);
+
+        if (!baseElement) {
+            return false;
+        }
+
+        const elements = rows ? withHeaderRow(baseElement, rows) : collectRows(baseElement);
+
+        return write(serializeRows(elements));
+    }
+
+    return {copy};
+}

--- a/packages/components/src/composable/private/useTableClipboard.ts
+++ b/packages/components/src/composable/private/useTableClipboard.ts
@@ -1,6 +1,6 @@
 import { useEventListener } from '@basmilius/common';
 import { type Ref, unref } from 'vue';
-import { getColumnSpan } from './useTableColumnIndex';
+import { CELL_SELECTOR, getColumnSpan, getRowSpan, HEADER_SELECTOR, INTERACTIVE_SELECTOR, isVisibleRow, ROW_SELECTOR } from './useTableColumnIndex';
 
 export type UseTableClipboardOptions = {
     getSelectedCells?(): ReadonlySet<HTMLElement>;
@@ -12,16 +12,18 @@ export type UseTableClipboardReturn = {
 
 type CopiedCell = {
     readonly colspan: number;
-    readonly isFullWidth: boolean;
     readonly isHeader: boolean;
     readonly rowspan: number;
     readonly value: string;
 };
 
-const CELL_SELECTOR = '[role="cell"], [role="gridcell"], [role="columnheader"]';
+type CopiedRow = {
+    readonly cells: CopiedCell[];
+    readonly isFullWidth: boolean;
+};
+
+const ANY_CELL_SELECTOR = `${CELL_SELECTOR}, ${HEADER_SELECTOR}`;
 const EXCLUDED_SELECTOR = '[data-flux-copy="none"]';
-const HEADER_SELECTOR = '[role="columnheader"]';
-const ROW_SELECTOR = '[role="row"]';
 const VALUE_ATTRIBUTE = 'data-flux-copy-value';
 
 function isExcluded(element: Element): boolean {
@@ -39,12 +41,6 @@ function escapeHtml(value: string): string {
         .replace(/>/g, '&gt;');
 }
 
-function getRowSpan(element: Element): number {
-    const span = Number.parseInt(element.getAttribute('aria-rowspan') ?? '', 10);
-
-    return Number.isNaN(span) || span < 1 ? 1 : span;
-}
-
 function readValue(cell: HTMLElement): string {
     const value = cell.getAttribute(VALUE_ATTRIBUTE);
 
@@ -59,7 +55,15 @@ function readValue(cell: HTMLElement): string {
     }
 
     const walker = document.createTreeWalker(cell, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
-        acceptNode: node => node.nodeType === Node.ELEMENT_NODE && isExcluded(node as Element) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+        acceptNode(node) {
+            if (node.nodeType !== Node.ELEMENT_NODE) {
+                return NodeFilter.FILTER_ACCEPT;
+            }
+
+            const element = node as HTMLElement;
+
+            return isExcluded(element) || element.style.display === 'none' ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+        }
     });
 
     const parts: string[] = [];
@@ -73,83 +77,99 @@ function readValue(cell: HTMLElement): string {
     return collapse(parts.join(''));
 }
 
-function serializeRow(row: HTMLElement, isIncluded?: (cell: HTMLElement) => boolean): CopiedCell[] {
-    const candidates = Array.from(row.children).filter(child => child.matches(CELL_SELECTOR) && !isExcluded(child)) as HTMLElement[];
-    const isFullWidth = candidates.length === 1;
+function serializeRow(row: HTMLElement, isIncluded?: (cell: HTMLElement) => boolean): CopiedRow {
+    const candidates = Array.from(row.children).filter(child => child.matches(ANY_CELL_SELECTOR) && !isExcluded(child)) as HTMLElement[];
 
-    return candidates
-        .filter(cell => !isIncluded || isIncluded(cell))
-        .map(cell => ({
-            colspan: getColumnSpan(cell),
-            isFullWidth,
-            isHeader: cell.matches(HEADER_SELECTOR),
-            rowspan: getRowSpan(cell),
-            value: readValue(cell)
-        }));
+    return {
+        cells: candidates
+            .filter(cell => !isIncluded || isIncluded(cell))
+            .map(cell => ({
+                colspan: getColumnSpan(cell),
+                isHeader: cell.matches(HEADER_SELECTOR),
+                rowspan: getRowSpan(cell),
+                value: readValue(cell)
+            })),
+        isFullWidth: candidates.length === 1
+    };
 }
 
-// A row of one cell spans the table: a group header, a section row, an expanded
-// row's detail. Its own colspan counts the columns that were left out, so it is
-// restated as the width that is actually being copied.
-function normalize(rows: CopiedCell[][]): CopiedCell[][] {
-    const widths = rows
-        .filter(cells => !isFullWidthRow(cells))
-        .map(cells => cells.reduce((total, cell) => total + cell.colspan, 0));
+// A full-width row's own colspan counts the columns that were left out, so it is
+// restated as the width actually being copied.
+function normalize(rows: CopiedRow[]): CopiedRow[] {
+    const width = Math.max(1, ...rows
+        .filter(row => !row.isFullWidth)
+        .map(row => row.cells.reduce((total, cell) => total + cell.colspan, 0)));
 
-    const width = Math.max(1, ...widths);
-
-    return rows.map(cells => isFullWidthRow(cells) ? [{...cells[0], colspan: width}] : cells);
+    return rows.map(row => row.isFullWidth ? {...row, cells: [{...row.cells[0], colspan: width}]} : row);
 }
 
-function isFullWidthRow(cells: CopiedCell[]): boolean {
-    return cells.length === 1 && cells[0].isFullWidth;
+function collectRows(baseElement: HTMLElement): HTMLElement[] {
+    return Array.from(baseElement.querySelectorAll<HTMLElement>(ROW_SELECTOR))
+        .filter(row => !isExcluded(row) && isVisibleRow(row));
 }
 
-function serializeRows(rows: HTMLElement[], isIncluded?: (cell: HTMLElement) => boolean): CopiedCell[][] {
+function serializeRows(rows: HTMLElement[], isIncluded?: (cell: HTMLElement) => boolean): CopiedRow[] {
     return normalize(rows
         .map(row => serializeRow(row, isIncluded))
-        .filter(cells => cells.length > 0));
+        .filter(row => row.cells.length > 0));
 }
 
-// A cell selection is already a rectangle, so it is copied as it stands: no header
-// row, and no rounding out of the rows it only partly covers.
-function serializeSelectedCells(baseElement: HTMLElement, cells: ReadonlySet<HTMLElement>): CopiedCell[][] {
+function serializeSelectedCells(baseElement: HTMLElement, cells: ReadonlySet<HTMLElement>): CopiedRow[] {
     const rows = collectRows(baseElement).filter(row => Array.from(row.children).some(child => cells.has(child as HTMLElement)));
 
     return serializeRows(rows, cell => cells.has(cell));
 }
 
-// A row is display: contents, which has no layout box, and checkVisibility() calls
-// anything without a box invisible. Only v-show hides a row, and that writes the
-// inline style this reads.
-function collectRows(baseElement: HTMLElement): HTMLElement[] {
-    return Array.from(baseElement.querySelectorAll<HTMLElement>(ROW_SELECTOR))
-        .filter(row => !isExcluded(row) && row.style.display !== 'none');
-}
-
-// Rows pasted without their column names land in a spreadsheet as anonymous
-// values, so whole rows are copied with the header row in front of them.
 function withHeaderRow(baseElement: HTMLElement, rows: readonly HTMLElement[]): HTMLElement[] {
-    if (rows.some(row => row.querySelector(HEADER_SELECTOR))) {
-        return Array.from(rows);
+    const visible = rows.filter(isVisibleRow);
+
+    if (visible.some(row => row.querySelector(HEADER_SELECTOR))) {
+        return visible;
     }
 
     const header = baseElement.querySelector<HTMLElement>(`${ROW_SELECTOR}:has(${HEADER_SELECTOR})`);
 
-    return header ? [header, ...rows] : Array.from(rows);
+    return header ? [header, ...visible] : visible;
 }
 
-function toText(rows: CopiedCell[][]): string {
+// Columns a rowspan above still occupies are filled with an empty value, so the
+// row after a spanning cell keeps its values under the right headers.
+function toText(rows: CopiedRow[]): string {
+    const carry: number[] = [];
+
     return rows
-        .map(cells => cells
-            .flatMap(cell => [cell.value, ...Array.from({length: cell.colspan - 1}, () => '')])
-            .join('\t'))
+        .map(({cells}) => {
+            const columns: string[] = [];
+            let index = 0;
+
+            const take = (): void => {
+                while (carry[index] > 0) {
+                    carry[index]--;
+                    columns[index] = '';
+                    index++;
+                }
+            };
+
+            for (const cell of cells) {
+                take();
+
+                for (let span = 0; span < cell.colspan; span++) {
+                    columns[index] = span === 0 ? cell.value : '';
+                    carry[index] = cell.rowspan - 1;
+                    index++;
+                }
+            }
+
+            take();
+
+            return columns.join('\t');
+        })
         .join('\n');
 }
 
-function toHtml(rows: CopiedCell[][]): string {
+function toHtml(rows: CopiedRow[]): string {
     const markup = rows
-        .map(cells => {
+        .map(({cells}) => {
             const columns = cells
                 .map(cell => {
                     const tag = cell.isHeader ? 'th' : 'td';
@@ -167,27 +187,15 @@ function toHtml(rows: CopiedCell[][]): string {
     return `<table>${markup}</table>`;
 }
 
-async function write(rows: CopiedCell[][]): Promise<boolean> {
-    if (rows.length === 0) {
+async function write(rows: CopiedRow[]): Promise<boolean> {
+    if (rows.length === 0 || !navigator.clipboard) {
         return false;
-    }
-
-    const text = toText(rows);
-
-    if (typeof ClipboardItem === 'undefined' || !navigator.clipboard?.write) {
-        if (!navigator.clipboard?.writeText) {
-            return false;
-        }
-
-        await navigator.clipboard.writeText(text);
-
-        return true;
     }
 
     await navigator.clipboard.write([
         new ClipboardItem({
             'text/html': new Blob([toHtml(rows)], {type: 'text/html'}),
-            'text/plain': new Blob([text], {type: 'text/plain'})
+            'text/plain': new Blob([toText(rows)], {type: 'text/plain'})
         })
     ]);
 
@@ -200,12 +208,28 @@ async function write(rows: CopiedCell[][]): Promise<boolean> {
  * receives a single column; both clipboard flavors are therefore written from the
  * table structure instead, tab separated and as real table markup.
  *
- * A cell states its own value with `data-flux-copy-value`, which is what lets a
- * formatted date or amount paste as the value behind it. Anything carrying
- * `data-flux-copy="none"` is left out: a whole row or cell when the attribute
- * sits on it, and only that subtree's text when it sits inside a cell.
+ * A cell states its own value with `data-flux-copy-value`. Anything carrying
+ * `data-flux-copy="none"` is left out: a whole row or cell when the attribute sits
+ * on it, and only that subtree's text when it sits inside a cell.
  */
 export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>, options?: UseTableClipboardOptions): UseTableClipboardReturn {
+    // A cell selection leaves the document selection empty, and a browser fires no
+    // copy event when nothing is selected, so the shortcut is handled here.
+    useEventListener(base, 'keydown', evt => {
+        const target = evt.target as Element | null;
+
+        if (!(evt.ctrlKey || evt.metaKey) || evt.key.toLowerCase() !== 'c' || target?.closest(INTERACTIVE_SELECTOR)) {
+            return;
+        }
+
+        if (!options?.getSelectedCells?.().size) {
+            return;
+        }
+
+        evt.preventDefault();
+        void copy();
+    });
+
     useEventListener(base, 'copy', evt => {
         const baseElement = unref(base);
 
@@ -240,38 +264,19 @@ export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>, optio
             return;
         }
 
-        // A drag ends halfway through its first and last row, which would copy those
-        // two rows short of the ones in between. Reaching a second row is therefore
-        // read as wanting those rows whole, column headers included; staying within
-        // one row keeps to the cells that were dragged over, and staying within one
-        // cell is an ordinary text copy that is left alone.
+        // A drag ends halfway through its first and last row, so reaching a second
+        // row is read as wanting those rows whole rather than as the cells it touched.
         const rows = touched.length > 1
             ? serializeRows(withHeaderRow(baseElement, touched))
             : normalize([serializeRow(touched[0], cell => range.intersectsNode(cell))]);
 
-        if (rows.length === 0 || (rows.length === 1 && rows[0].length < 2)) {
+        if (rows.length === 0 || (rows.length === 1 && rows[0].cells.length < 2)) {
             return;
         }
 
         evt.preventDefault();
         evt.clipboardData.setData('text/plain', toText(rows));
         evt.clipboardData.setData('text/html', toHtml(rows));
-    });
-
-    // A cell selection leaves the document selection empty, and a browser fires no
-    // copy event when there is nothing selected, so the shortcut is handled here.
-    // Preventing the default keeps the native copy from running twice.
-    useEventListener(base, 'keydown', evt => {
-        if (!(evt.ctrlKey || evt.metaKey) || evt.key.toLowerCase() !== 'c' || !navigator.clipboard) {
-            return;
-        }
-
-        if (!options?.getSelectedCells?.().size) {
-            return;
-        }
-
-        evt.preventDefault();
-        void copy();
     });
 
     async function copy(rows?: readonly HTMLElement[]): Promise<boolean> {
@@ -281,17 +286,13 @@ export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>, optio
             return false;
         }
 
-        // Without rows to copy, a cell selection is what the user pointed at and
-        // outranks the whole table this would otherwise hand over.
         const cells = rows ? undefined : options?.getSelectedCells?.();
 
         if (cells?.size) {
             return write(serializeSelectedCells(baseElement, cells));
         }
 
-        const elements = rows ? withHeaderRow(baseElement, rows) : collectRows(baseElement);
-
-        return write(serializeRows(elements));
+        return write(serializeRows(rows ? withHeaderRow(baseElement, rows) : collectRows(baseElement)));
     }
 
     return {copy};

--- a/packages/components/src/composable/private/useTableClipboard.ts
+++ b/packages/components/src/composable/private/useTableClipboard.ts
@@ -2,6 +2,10 @@ import { useEventListener } from '@basmilius/common';
 import { type Ref, unref } from 'vue';
 import { getColumnSpan } from './useTableColumnIndex';
 
+export type UseTableClipboardOptions = {
+    getSelectedCells?(): ReadonlySet<HTMLElement>;
+};
+
 export type UseTableClipboardReturn = {
     copy(rows?: readonly HTMLElement[]): Promise<boolean>;
 };
@@ -14,7 +18,7 @@ type CopiedCell = {
     readonly value: string;
 };
 
-const CELL_SELECTOR = '[role="cell"], [role="columnheader"]';
+const CELL_SELECTOR = '[role="cell"], [role="gridcell"], [role="columnheader"]';
 const EXCLUDED_SELECTOR = '[data-flux-copy="none"]';
 const HEADER_SELECTOR = '[role="columnheader"]';
 const ROW_SELECTOR = '[role="row"]';
@@ -107,9 +111,20 @@ function serializeRows(rows: HTMLElement[], isIncluded?: (cell: HTMLElement) => 
         .filter(cells => cells.length > 0));
 }
 
+// A cell selection is already a rectangle, so it is copied as it stands: no header
+// row, and no rounding out of the rows it only partly covers.
+function serializeSelectedCells(baseElement: HTMLElement, cells: ReadonlySet<HTMLElement>): CopiedCell[][] {
+    const rows = collectRows(baseElement).filter(row => Array.from(row.children).some(child => cells.has(child as HTMLElement)));
+
+    return serializeRows(rows, cell => cells.has(cell));
+}
+
+// A row is display: contents, which has no layout box, and checkVisibility() calls
+// anything without a box invisible. Only v-show hides a row, and that writes the
+// inline style this reads.
 function collectRows(baseElement: HTMLElement): HTMLElement[] {
     return Array.from(baseElement.querySelectorAll<HTMLElement>(ROW_SELECTOR))
-        .filter(row => !isExcluded(row) && (row.checkVisibility?.() ?? true));
+        .filter(row => !isExcluded(row) && row.style.display !== 'none');
 }
 
 // Rows pasted without their column names land in a spreadsheet as anonymous
@@ -190,12 +205,31 @@ async function write(rows: CopiedCell[][]): Promise<boolean> {
  * `data-flux-copy="none"` is left out: a whole row or cell when the attribute
  * sits on it, and only that subtree's text when it sits inside a cell.
  */
-export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>): UseTableClipboardReturn {
+export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>, options?: UseTableClipboardOptions): UseTableClipboardReturn {
     useEventListener(base, 'copy', evt => {
         const baseElement = unref(base);
+
+        if (!baseElement || !evt.clipboardData) {
+            return;
+        }
+
+        const cells = options?.getSelectedCells?.();
+
+        if (cells?.size) {
+            const selected = serializeSelectedCells(baseElement, cells);
+
+            if (selected.length > 0) {
+                evt.preventDefault();
+                evt.clipboardData.setData('text/plain', toText(selected));
+                evt.clipboardData.setData('text/html', toHtml(selected));
+            }
+
+            return;
+        }
+
         const selection = window.getSelection();
 
-        if (!baseElement || !evt.clipboardData || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
             return;
         }
 
@@ -224,11 +258,35 @@ export function useTableClipboard(base: Readonly<Ref<HTMLElement | null>>): UseT
         evt.clipboardData.setData('text/html', toHtml(rows));
     });
 
+    // A cell selection leaves the document selection empty, and a browser fires no
+    // copy event when there is nothing selected, so the shortcut is handled here.
+    // Preventing the default keeps the native copy from running twice.
+    useEventListener(base, 'keydown', evt => {
+        if (!(evt.ctrlKey || evt.metaKey) || evt.key.toLowerCase() !== 'c' || !navigator.clipboard) {
+            return;
+        }
+
+        if (!options?.getSelectedCells?.().size) {
+            return;
+        }
+
+        evt.preventDefault();
+        void copy();
+    });
+
     async function copy(rows?: readonly HTMLElement[]): Promise<boolean> {
         const baseElement = unref(base);
 
         if (!baseElement) {
             return false;
+        }
+
+        // Without rows to copy, a cell selection is what the user pointed at and
+        // outranks the whole table this would otherwise hand over.
+        const cells = rows ? undefined : options?.getSelectedCells?.();
+
+        if (cells?.size) {
+            return write(serializeSelectedCells(baseElement, cells));
         }
 
         const elements = rows ? withHeaderRow(baseElement, rows) : collectRows(baseElement);

--- a/packages/components/src/composable/private/useTableColumnIndex.ts
+++ b/packages/components/src/composable/private/useTableColumnIndex.ts
@@ -1,15 +1,37 @@
 import { computed, type ComputedRef, type Ref, unref } from 'vue';
 import type { FluxTableColumnDef } from '~flux/components/data';
 
+export const CELL_SELECTOR = '[role="cell"], [role="gridcell"]';
+export const HEADER_SELECTOR = '[role="columnheader"]';
+export const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
+export const ROW_SELECTOR = '[role="row"]';
+
 /**
  * Returns how many columns a cell occupies. `aria-colspan` is the single place
  * in the DOM that carries this, for assistive technology and for the column
  * bookkeeping alike.
  */
 export function getColumnSpan(element: Element): number {
-    const span = Number.parseInt(element.getAttribute('aria-colspan') ?? '', 10);
+    return readSpan(element, 'aria-colspan');
+}
+
+/**
+ * Returns how many rows a cell occupies.
+ */
+export function getRowSpan(element: Element): number {
+    return readSpan(element, 'aria-rowspan');
+}
+
+function readSpan(element: Element, attribute: string): number {
+    const span = Number.parseInt(element.getAttribute(attribute) ?? '', 10);
 
     return Number.isNaN(span) || span < 1 ? 1 : span;
+}
+
+// A row is display: contents, which has no layout box, and checkVisibility() calls
+// anything without a box invisible. Only v-show hides a row, and it writes this.
+export function isVisibleRow(row: HTMLElement): boolean {
+    return row.style.display !== 'none';
 }
 
 /**

--- a/packages/components/src/composable/private/useTableColumnIndex.ts
+++ b/packages/components/src/composable/private/useTableColumnIndex.ts
@@ -3,6 +3,7 @@ import type { FluxTableColumnDef } from '~flux/components/data';
 
 export const CELL_SELECTOR = '[role="cell"], [role="gridcell"]';
 export const HEADER_SELECTOR = '[role="columnheader"]';
+export const ANY_CELL_SELECTOR = `${CELL_SELECTOR}, ${HEADER_SELECTOR}`;
 export const INTERACTIVE_SELECTOR = 'a, button, input, label, select, textarea, [role="button"]';
 export const ROW_SELECTOR = '[role="row"]';
 

--- a/packages/components/src/composable/useTableInjection.ts
+++ b/packages/components/src/composable/useTableInjection.ts
@@ -4,6 +4,7 @@ import { FluxTableInjectionKey } from '~flux/components/data';
 export default function () {
     return inject(FluxTableInjectionKey, () => ({
         activeRow: ref(null),
+        cellRole: ref('cell' as const),
         columns: ref([]),
         pinnedEdges: ref({end: -1, start: -1}),
         pinnedOffsets: ref(new Map<number, number>()),

--- a/packages/components/src/composable/useTableInjection.ts
+++ b/packages/components/src/composable/useTableInjection.ts
@@ -4,7 +4,7 @@ import { FluxTableInjectionKey } from '~flux/components/data';
 export default function () {
     return inject(FluxTableInjectionKey, () => ({
         activeRow: ref(null),
-        cellRole: ref('cell' as const),
+        cellRole: ref<'cell' | 'gridcell'>('cell'),
         columns: ref([]),
         pinnedEdges: ref({end: -1, start: -1}),
         pinnedOffsets: ref(new Map<number, number>()),

--- a/packages/components/src/css/component/Table.module.scss
+++ b/packages/components/src/css/component/Table.module.scss
@@ -22,6 +22,8 @@
 
 .tableLoader {
     composes: basePaneLoader from './base/Pane.module.scss';
+
+    user-select: none;
 }
 
 .tableHead,
@@ -223,10 +225,12 @@
 
 .tableActions {
     margin: -4px 0 -4px -3px;
+    user-select: none;
 }
 
 .tableCellSelection {
     white-space: nowrap;
+    user-select: none;
 }
 
 .tableCell.isNoWrap {
@@ -275,6 +279,7 @@
 .tableFill {
     pointer-events: none;
     border-top: 1px solid var(--surface-stroke-muted);
+    user-select: none;
 
     .tableCell {
         padding: 0;
@@ -375,6 +380,7 @@
 .tableGroupChevron {
     color: var(--foreground-secondary);
     transition: rotate .2s var(--swift-out);
+    user-select: none;
 }
 
 .tableGroupChevron.isExpanded {
@@ -438,6 +444,7 @@
     color: var(--foreground-secondary);
     cursor: pointer;
     outline: 0;
+    user-select: none;
 
     @include mixin.hover {
         background: var(--surface-active);
@@ -517,6 +524,7 @@
 
 .tableCellExpand {
     white-space: nowrap;
+    user-select: none;
 }
 
 .tableExpandToggle :global(svg) {
@@ -575,6 +583,7 @@
     border-radius: 50%;
     color: var(--tree-marker-foreground);
     translate: 0 -50%;
+    user-select: none;
     z-index: 1;
 }
 

--- a/packages/components/src/css/component/Table.module.scss
+++ b/packages/components/src/css/component/Table.module.scss
@@ -191,9 +191,15 @@
     user-select: none;
 }
 
+// The sort button and the resize grip keep their own cursor, so only the header's
+// own surface offers the column.
+.table.isCellSelectable .tableHeader {
+    cursor: cell;
+}
+
 // Four inset shadows rather than a border, which would take the cells off the 3px
 // grid, and rather than an outline, which cannot draw a single side.
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected] {
+.table.isCellSelectable .tableCell[data-flux-selected] {
     background: var(--primary-soft);
     box-shadow: inset 0 2px 0 0 var(--selection-edge-top, transparent),
                 inset -2px 0 0 0 var(--selection-edge-right, transparent),
@@ -204,29 +210,29 @@
 
 // The divider only loses its color where the outline covers it; the width stays,
 // and with it the layout.
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='top'] {
+.table.isCellSelectable .tableCell[data-flux-selected~='top'] {
     --selection-edge-top: var(--primary-solid);
 
     border-top-color: transparent;
 }
 
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='left'] {
+.table.isCellSelectable .tableCell[data-flux-selected~='left'] {
     --selection-edge-left: var(--primary-solid);
 
     border-left-color: transparent;
 }
 
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='right'] {
+.table.isCellSelectable .tableCell[data-flux-selected~='right'] {
     --selection-edge-right: var(--primary-solid);
 }
 
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='bottom'] {
+.table.isCellSelectable .tableCell[data-flux-selected~='bottom'] {
     --selection-edge-bottom: var(--primary-solid);
 }
 
 // No focus ring of its own: the block outline appears the moment the table takes
 // focus, and a ring inside it would read as a thicker line.
-.table.isCellSelectable .tableBody .tableCell[data-flux-active] {
+.table.isCellSelectable .tableCell[data-flux-active] {
     background: var(--primary-soft-hover);
 }
 

--- a/packages/components/src/css/component/Table.module.scss
+++ b/packages/components/src/css/component/Table.module.scss
@@ -158,29 +158,30 @@
 
 // Hover keys off :has(:hover): a display: contents row has no box of its own, its cells do.
 // A bare media query rather than mixin.hover, which nests &:hover onto a single selector
-// while this needs several unrelated ones under one condition.
+// while this needs several unrelated ones under one condition. Row hover stands down
+// under cell selection: it outranks the selection colors and reads as noise per cell.
 @media (hover: hover) {
-    .table.isHoverable .tableBody .tableRow:has(:hover) > .tableCell:not(.tableGroup):not(.hasRowspan),
-    .table.isHoverable .tableBody .tableRow:has(:focus-visible) > .tableCell:not(.tableGroup):not(.hasRowspan),
-    .table.isHoverable .tableBody .tableRow:has(:hover) > .tableGroup.isHoverable,
-    .table.isHoverable .tableBody .tableRow:has(:focus-visible) > .tableGroup.isHoverable {
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow:has(:hover) > .tableCell:not(.tableGroup):not(.hasRowspan),
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow:has(:focus-visible) > .tableCell:not(.tableGroup):not(.hasRowspan),
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow:has(:hover) > .tableGroup.isHoverable,
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow:has(:focus-visible) > .tableGroup.isHoverable {
         background: var(--surface-hover);
     }
 
-    .table.isHoverable .tableBody .tableRow.isColored:has(:hover) > .tableCell:not(.hasRowspan),
-    .table.isHoverable .tableBody .tableRow.isColored:has(:focus-visible) > .tableCell:not(.hasRowspan) {
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow.isColored:has(:hover) > .tableCell:not(.hasRowspan),
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow.isColored:has(:focus-visible) > .tableCell:not(.hasRowspan) {
         background: var(--table-row-fill-hover);
     }
 
-    .table.isHoverable .tableBody .tableRow.isSelected:has(:hover) > .tableCell:not(.hasRowspan),
-    .table.isHoverable .tableBody .tableRow.isSelected:has(:focus-visible) > .tableCell:not(.hasRowspan) {
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow.isSelected:has(:hover) > .tableCell:not(.hasRowspan),
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow.isSelected:has(:focus-visible) > .tableCell:not(.hasRowspan) {
         --table-row-stroke: var(--primary-soft-hover);
 
         background: var(--primary-soft);
     }
 
-    .table.isHoverable .tableBody .tableRow:has(:hover) > .tableCell:not(.hasRowspan),
-    .table.isHoverable .tableBody .tableRow:has(:focus-visible) > .tableCell:not(.hasRowspan) {
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow:has(:hover) > .tableCell:not(.hasRowspan),
+    .table.isHoverable:not(.isCellSelectable) .tableBody .tableRow:has(:focus-visible) > .tableCell:not(.hasRowspan) {
         border-top-color: var(--table-row-stroke, var(--surface-stroke-muted));
     }
 }
@@ -190,10 +191,8 @@
     user-select: none;
 }
 
-// The selection paints over a pinned cell's own background, which is why these
-// outrank it; the attributes are set imperatively, so nothing here is bound.
-// The outline is four inset shadows instead of a border, which would take the
-// cells off the 3px grid, and instead of an outline, which cannot do one side.
+// Four inset shadows rather than a border, which would take the cells off the 3px
+// grid, and rather than an outline, which cannot draw a single side.
 .table.isCellSelectable .tableBody .tableCell[data-flux-selected] {
     background: var(--primary-soft);
     box-shadow: inset 0 2px 0 0 var(--selection-edge-top, transparent),
@@ -203,8 +202,18 @@
     color: var(--primary-text);
 }
 
+// The divider only loses its color where the outline covers it; the width stays,
+// and with it the layout.
 .table.isCellSelectable .tableBody .tableCell[data-flux-selected~='top'] {
     --selection-edge-top: var(--primary-solid);
+
+    border-top-color: transparent;
+}
+
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='left'] {
+    --selection-edge-left: var(--primary-solid);
+
+    border-left-color: transparent;
 }
 
 .table.isCellSelectable .tableBody .tableCell[data-flux-selected~='right'] {
@@ -215,22 +224,8 @@
     --selection-edge-bottom: var(--primary-solid);
 }
 
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='left'] {
-    --selection-edge-left: var(--primary-solid);
-}
-
-// The cell keeps its 1px divider on the sides it did not draw, so only the sides
-// the outline covers lose their color; the width stays, and with it the layout.
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='top'] {
-    border-top-color: transparent;
-}
-
-.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='left'] {
-    border-left-color: transparent;
-}
-
 // No focus ring of its own: the block outline appears the moment the table takes
-// focus, and a ring inside it would read as a thicker line rather than a mark.
+// focus, and a ring inside it would read as a thicker line.
 .table.isCellSelectable .tableBody .tableCell[data-flux-active] {
     background: var(--primary-soft-hover);
 }

--- a/packages/components/src/css/component/Table.module.scss
+++ b/packages/components/src/css/component/Table.module.scss
@@ -185,6 +185,56 @@
     }
 }
 
+.table.isCellSelectable .tableBase {
+    outline: 0;
+    user-select: none;
+}
+
+// The selection paints over a pinned cell's own background, which is why these
+// outrank it; the attributes are set imperatively, so nothing here is bound.
+// The outline is four inset shadows instead of a border, which would take the
+// cells off the 3px grid, and instead of an outline, which cannot do one side.
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected] {
+    background: var(--primary-soft);
+    box-shadow: inset 0 2px 0 0 var(--selection-edge-top, transparent),
+                inset -2px 0 0 0 var(--selection-edge-right, transparent),
+                inset 0 -2px 0 0 var(--selection-edge-bottom, transparent),
+                inset 2px 0 0 0 var(--selection-edge-left, transparent);
+    color: var(--primary-text);
+}
+
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='top'] {
+    --selection-edge-top: var(--primary-solid);
+}
+
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='right'] {
+    --selection-edge-right: var(--primary-solid);
+}
+
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='bottom'] {
+    --selection-edge-bottom: var(--primary-solid);
+}
+
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='left'] {
+    --selection-edge-left: var(--primary-solid);
+}
+
+// The cell keeps its 1px divider on the sides it did not draw, so only the sides
+// the outline covers lose their color; the width stays, and with it the layout.
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='top'] {
+    border-top-color: transparent;
+}
+
+.table.isCellSelectable .tableBody .tableCell[data-flux-selected~='left'] {
+    border-left-color: transparent;
+}
+
+// No focus ring of its own: the block outline appears the moment the table takes
+// focus, and a ring inside it would read as a thicker line rather than a mark.
+.table.isCellSelectable .tableBody .tableCell[data-flux-active] {
+    background: var(--primary-soft-hover);
+}
+
 .tableFoot .tableCell {
     border-top: 1px solid var(--surface-stroke-muted);
 }

--- a/packages/components/src/data/di.ts
+++ b/packages/components/src/data/di.ts
@@ -319,6 +319,7 @@ export type FluxTablePinnedEdges = {
 
 export type FluxTableInjection = {
     readonly activeRow: Ref<HTMLElement | null>;
+    readonly cellRole: Readonly<Ref<'cell' | 'gridcell'>>;
     readonly columns: Readonly<Ref<readonly FluxTableColumnDef[]>>;
     readonly pinnedEdges: Ref<FluxTablePinnedEdges>;
     readonly pinnedOffsets: Ref<Map<number, number>>;


### PR DESCRIPTION
A table that is a CSS grid rather than a `<table>` copies badly: a browser hands over one line per cell with nothing marking where a row ends, so a copy out of the table pastes into a spreadsheet as a single column. This branch makes the table write the clipboard itself, and then builds an opt-in spreadsheet-style cell selection on top of it.

Four commits, each self-contained.

## Writing the clipboard from the table structure

The table serializes both clipboard flavors itself, tab separated and as real table markup, scaled to how far the selection reaches:

- **Across several rows** the rows are copied whole, with the column headers in front of them. A drag ends halfway through its first and last row, which would otherwise copy those two short of the rows in between.
- **Within one row** only the cells that were dragged over, without headers.
- **Within one cell** nothing at all, so dragging over a few words still copies those words.

Two attributes steer it, on any element inside the table:

- `data-flux-copy-value` states the value a cell copies instead of the text it renders. `FluxTableCell` takes it as the new **`copy-value`** prop, so a formatted amount pastes as `1234.56` rather than `$ 1,234.56`.
- `data-flux-copy="none"` leaves something out. On a row or a cell it drops that row or cell; inside a cell it only drops that subtree's text, so the cell still copies as an empty column and the columns stay aligned.

The table bar, the filler row, the sort and resize controls and the data table's selection and expand columns carry it already, and the chrome is kept out of a text selection with `user-select: none`.

The table instance exposes **`copy(rows?)`**. Without arguments it copies the current cell selection, or the whole table when there is none. `FluxDataTable` builds a **`copy()`** binding on its `selection` slot on top of that, and marks its rows with `aria-selected`.

## Opt-in cell selection

**`is-cell-selectable`** turns the body into a grid of selectable cells: drag a rectangle, shift-click to extend it, or walk it with the arrow keys. Copying hands over exactly that rectangle, so it pastes in the shape it was selected.

The column headers are row zero of that grid, which makes a click on a header mean "this column, header included" rather than a case of its own, and lets a shift-click extend it to a range of columns. A drag that starts on a header stays in column mode. A rectangle taken from the body brings the headers of the columns it covers along, unless it already holds them or stays within a single row: the rule a text selection already followed.

| Key | Does |
| --- | --- |
| `Arrow` keys | Move the active cell |
| `Shift` + arrow | Extend the rectangle |
| `Home` / `End` | First or last cell of the row |
| `Ctrl`/`Cmd` + `Home` / `End` | First or last cell of the table |
| `Ctrl`/`Cmd` + `A` | Select every cell |
| `Ctrl`/`Cmd` + `C` | Copy the rectangle |
| `Escape` | Clear the selection |

The table itself is the single tab stop and names the active cell through `aria-activedescendant`, so a thousand-cell table keeps one focusable element. It reports itself as a `grid` while the mode is on and its cells as `gridcell`, through the table injection. The rectangle is painted by setting attributes on the cells that changed rather than by rendering it, and the block is outlined as a whole: every cell carries the sides of the rectangle it forms.

Two notes worth knowing when reviewing:

- The copy shortcut is handled directly rather than through a `copy` event, since a cell selection leaves the document selection empty and no `copy` event fires. It stands down inside an input, so typing in a cell and copying still hands over the typed text.
- Rows are collected by their inline `display` rather than `checkVisibility()`, which reports every `display: contents` row as invisible and dropped them all.

**Cell selection and clickable rows cannot share a table**, since both own the roving tabindex and the arrow keys. On `FluxDataTable` that means no `selection-mode` and no `row-click` listener; passing `is-cell-selectable` anyway logs a warning and leaves the mode off.

## What a first review round already caught

The third commit is a fix pass over the two above. In the order they bite:

- The cell selection held element references that nothing invalidated, so replacing the rows without clicking in the table left it pointing at detached cells: `aria-activedescendant` named a gone id and copying silently produced nothing. A mutation observer drops the selection, but only when rows actually come or go.
- `FluxTableRow` looked for `role="cell"` and `role="table"`, both of which the cell selection renames, so row clicks and arrow navigation broke wherever a hand-built table combined clickable rows with the mode.
- Row hover outranked the selection colors, so a selected cell under the pointer turned grey again.
- A group row spans every column but declared none, so arrow-down out of the second column landed on nothing.
- The plain-text flavor ignored `rowspan`, shifting every row after a spanning cell one column to the left. It now carries occupied columns forward.
- `copy(rows)` skipped the visibility filter, so a collapsed group's rows came along.
- `isDragging` only reset on `lostpointercapture`, leaving the drag stuck if `setPointerCapture` never took.

## Public API

Additive only.

| | |
| --- | --- |
| `FluxTable` | `is-cell-selectable` prop; `copy(rows?)` and `clearSelection()` on the instance |
| `FluxTableCell` | `copy-value` prop |
| `FluxDataTable` | `is-cell-selectable` prop; `copy()` on the `selection` slot |
| `useTableInjection` | gains the cell-selection flag the cells read |

New private composables: `useTableCellSelection` and `useTableClipboard`. `useTableColumnIndex` gains `getRowSpan` and `isVisibleRow` next to `getColumnSpan`, plus the shared selectors.

## Docs

A **Copying data** and a **Cell selection** section on the table page, two runnable examples (`table/cell-selection.vue` and `data-table/selection-copy.vue`), and the new props on the three frontmatter tables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spreadsheet-style cell selection for tables, including mouse and keyboard range selection.
  * Added copying of selected cells, headers, and rows to the clipboard.
  * Added custom clipboard values for table cells.
  * Added accessibility support and visual styling for active and selected cells.
  * Added examples demonstrating row and cell selection with copy actions.

* **Documentation**
  * Documented cell selection, copying behavior, accessibility considerations, and compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->