### PR TITLE
fix(statistics): stop the chart pane from sizing an empty state by aspect ratio

### DIFF
--- a/packages/statistics/src/css/ChartPane.module.scss
+++ b/packages/statistics/src/css/ChartPane.module.scss
@@ -33,6 +33,13 @@
             height: calc(40cqw / var(--aspect-ratio, 1));
         }
     }
+
+    &:has(.statisticsEmpty) {
+        .statisticsChartPaneContainer {
+            height: auto;
+            min-height: var(--min-height, 240px);
+        }
+    }
 }
 
 .statisticsChartPaneContainer {


### PR DESCRIPTION
Closes #42.

`FluxStatisticsChartPane` derives its container height from the pane's aspect ratio, which is right for a chart but wrong for a `FluxStatisticsEmpty` rendered as that chart's empty state: with `:aspect-ratio="1"` on a wide pane the card becomes a huge square holding one icon and two lines of text. It gets worse when the legend is hidden in the empty state, because the container then falls back from `calc(40cqw / ratio)` to `calc(100cqw / ratio)`.

An empty state now gets a compact height instead, following the existing `&:has(.statisticsLegend)` pattern:

```scss
&:has(.statisticsEmpty) {
    .statisticsChartPaneContainer {
        height: auto;
        min-height: var(--min-height, 240px);
    }
}
```

`min-height` stays configurable through the pane's `min-height` prop, so a caller that wants a taller empty state still wins.

This cannot be fixed downstream: class names are scoped per package, so an app consuming `@flux-ui/statistics` cannot target `.statisticsChartPaneContainer` — not through `:global(.statistics-chart-pane-container)` (that name does not survive scoping) and not through a same-named class in its own module (which lands on a different scoped class).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the chart pane’s empty state with a minimum height of 240px.
  * Added support for configuring the minimum height when needed.
  * Ensured the chart pane adapts its height automatically when no data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->